### PR TITLE
Auto-instantiate proof of adjunction alongside section and retraction (cf., #57)

### DIFF
--- a/plugin/_CoqProject
+++ b/plugin/_CoqProject
@@ -61,6 +61,7 @@ src/frontend.mli
 src/ornamental.ml4
 src/ornaments.mlpack
 
+theories/Adjoint.v
 theories/Unpack.v
 theories/Lifted.v
 theories/Ornaments.v

--- a/plugin/coq/Test.v
+++ b/plugin/coq/Test.v
@@ -66,7 +66,7 @@ Qed.
 
 Theorem test_adjunction:
   forall (A : Type) (l : list A),
-    orn_list_vector_retraction A (orn_list_vector A l) =
+    orn_list_vector_retraction_adjoint A (orn_list_vector A l) =
     f_equal (orn_list_vector A) (orn_list_vector_section A l).
 Proof.
   exact orn_list_vector_adjunction.
@@ -127,7 +127,7 @@ Qed.
 
 Theorem test_adjunction_auto:
   forall (A : Type) (l : list A),
-    list_to_vector_retraction A (list_to_vector A l) =
+    list_to_vector_retraction_adjoint A (list_to_vector A l) =
     f_equal (list_to_vector A) (list_to_vector_section A l).
 Proof.
   exact list_to_vector_adjunction.
@@ -314,7 +314,7 @@ Qed.
 
 Theorem test_adjunction_2:
   forall (A : Type) (l : rev_list A),
-    orn_rev_list_rev_vector_retraction A (orn_rev_list_rev_vector A l) =
+    orn_rev_list_rev_vector_retraction_adjoint A (orn_rev_list_rev_vector A l) =
     f_equal (orn_rev_list_rev_vector A) (orn_rev_list_rev_vector_section A l).
 Proof.
   exact orn_rev_list_rev_vector_adjunction.
@@ -400,7 +400,7 @@ Qed.
 
 Theorem test_adjunction_3:
   forall (A : Type) (tr : bintree A),
-    orn_bintree_bintreeV_retraction A (orn_bintree_bintreeV A tr) =
+    orn_bintree_bintreeV_retraction_adjoint A (orn_bintree_bintreeV A tr) =
     f_equal (orn_bintree_bintreeV A) (orn_bintree_bintreeV_section A tr).
 Proof.
   exact orn_bintree_bintreeV_adjunction.
@@ -482,7 +482,7 @@ Qed.
 
 Theorem test_adjunction_4:
   forall (A B : Type) (l : list2 A B),
-    orn_list2_vector2_retraction A B (orn_list2_vector2 A B l) =
+    orn_list2_vector2_retraction_adjoint A B (orn_list2_vector2 A B l) =
     f_equal (orn_list2_vector2 A B) (orn_list2_vector2_section A B l).
 Proof.
   exact orn_list2_vector2_adjunction.
@@ -562,7 +562,7 @@ Qed.
 
 Theorem test_adjunction_5:
   forall (l : nat_list),
-    orn_natlist_natvector_retraction (orn_natlist_natvector l) =
+    orn_natlist_natvector_retraction_adjoint (orn_natlist_natvector l) =
     f_equal orn_natlist_natvector (orn_natlist_natvector_section l).
 Proof.
   exact orn_natlist_natvector_adjunction.
@@ -642,7 +642,7 @@ Qed.
 
 Theorem test_adjunction_6:
   forall (A : Type) (tr : bintree A),
-    orn_bintree_bintreeV_rev_retraction A (orn_bintree_bintreeV_rev A tr) =
+    orn_bintree_bintreeV_rev_retraction_adjoint A (orn_bintree_bintreeV_rev A tr) =
     f_equal (orn_bintree_bintreeV_rev A) (orn_bintree_bintreeV_rev_section A tr).
 Proof.
   exact orn_bintree_bintreeV_rev_adjunction.
@@ -722,7 +722,7 @@ Qed.
 
 Theorem test_adjunction_7:
   forall (A : Type) (n : nat) (v : vector A n),
-    orn_vector_doublevector_retraction A n (orn_vector_doublevector A n v) =
+    orn_vector_doublevector_retraction_adjoint A n (orn_vector_doublevector A n v) =
     f_equal (orn_vector_doublevector A n) (orn_vector_doublevector_section A n v).
 Proof.
   exact orn_vector_doublevector_adjunction.
@@ -792,7 +792,7 @@ Qed.
 
 Theorem test_adjunction_8:
   forall (A : Type) (n : nat) (v : vector A n),
-    orn_vector_doublevector2_retraction A n (orn_vector_doublevector2 A n v) =
+    orn_vector_doublevector2_retraction_adjoint A n (orn_vector_doublevector2 A n v) =
     f_equal (orn_vector_doublevector2 A n) (orn_vector_doublevector2_section A n v).
 Proof.
   exact orn_vector_doublevector2_adjunction.
@@ -872,7 +872,7 @@ Qed.
 
 Theorem test_adjunction_9:
   forall (A : Type) (n : nat) (v : vector A n),
-    orn_vector_doublevector3_retraction A n (orn_vector_doublevector3 A n v) =
+    orn_vector_doublevector3_retraction_adjoint A n (orn_vector_doublevector3 A n v) =
     f_equal (orn_vector_doublevector3 A n) (orn_vector_doublevector3_section A n v).
 Proof.
   exact orn_vector_doublevector3_adjunction.
@@ -953,7 +953,7 @@ Qed.
 
 Theorem test_adjunction_10:
   forall (A : Type) (n : nat) (v : vector A n),
-    orn_vector_doublevector4_retraction A n (orn_vector_doublevector4 A n v) =
+    orn_vector_doublevector4_retraction_adjoint A n (orn_vector_doublevector4 A n v) =
     f_equal (orn_vector_doublevector4 A n) (orn_vector_doublevector4_section A n v).
 Proof.
   exact orn_vector_doublevector4_adjunction.
@@ -1032,7 +1032,7 @@ Qed.
 
 Theorem test_adjunction_11:
   forall (nl : nat_list),
-    orn_natlist_hdnatlist_retraction (orn_natlist_hdnatlist nl) =
+    orn_natlist_hdnatlist_retraction_adjoint (orn_natlist_hdnatlist nl) =
     f_equal orn_natlist_hdnatlist (orn_natlist_hdnatlist_section nl).
 Proof.
   exact orn_natlist_hdnatlist_adjunction.
@@ -1103,7 +1103,7 @@ Qed.
 
 Theorem test_adjunction_12:
   forall (A : Type) (l : list A),
-    orn_list_hdlist_retraction A (orn_list_hdlist A l) =
+    orn_list_hdlist_retraction_adjoint A (orn_list_hdlist A l) =
     f_equal (orn_list_hdlist A) (orn_list_hdlist_section A l).
 Proof.
   exact orn_list_hdlist_adjunction.
@@ -1188,7 +1188,7 @@ Qed.
 
 Theorem test_adjunction_13:
   forall (A : Type) (l : list_alt A),
-    orn_listalt_hdlistalt_retraction A (orn_listalt_hdlistalt A l) =
+    orn_listalt_hdlistalt_retraction_adjoint A (orn_listalt_hdlistalt A l) =
     f_equal (orn_listalt_hdlistalt A) (orn_listalt_hdlistalt_section A l).
 Proof.
   exact orn_listalt_hdlistalt_adjunction.
@@ -1264,7 +1264,7 @@ Qed.
 
 Theorem test_adjunction_14:
   forall (n : nat),
-    orn_nat_natnat_retraction (orn_nat_natnat n) =
+    orn_nat_natnat_retraction_adjoint (orn_nat_natnat n) =
     f_equal orn_nat_natnat (orn_nat_natnat_section n).
 Proof.
   exact orn_nat_natnat_adjunction.
@@ -1338,7 +1338,7 @@ Qed.
 
 Theorem test_adjunction_15:
   forall (A : Type) (n : nat) (v : vector A n),
-    orn_vector_doublevector5_retraction A n (orn_vector_doublevector5 A n v) =
+    orn_vector_doublevector5_retraction_adjoint A n (orn_vector_doublevector5 A n v) =
     f_equal (orn_vector_doublevector5 A n) (orn_vector_doublevector5_section A n v).
 Proof.
   exact orn_vector_doublevector5_adjunction.
@@ -1438,7 +1438,7 @@ Qed.
 
 Theorem test_adjunction_16:
   forall (n m : nat) (b : _bst n m),
-    _bst_to_bst_retraction n m (_bst_to_bst n m b) =
+    _bst_to_bst_retraction_adjoint n m (_bst_to_bst n m b) =
     f_equal (_bst_to_bst n m) (_bst_to_bst_section n m b).
 Proof.
   exact _bst_to_bst_adjunction.
@@ -1509,7 +1509,7 @@ Qed.
 
 Theorem test_adjunction_17:
   forall (n m : nat) (b : _bst n m),
-    _bst_to_bst2_retraction n m (_bst_to_bst2 n m b) =
+    _bst_to_bst2_retraction_adjoint n m (_bst_to_bst2 n m b) =
     f_equal (_bst_to_bst2 n m) (_bst_to_bst2_section n m b).
 Proof.
   exact _bst_to_bst2_adjunction.
@@ -1580,7 +1580,7 @@ Qed.
 
 Theorem test_adjunction_18:
   forall (n m : nat) (b : _bst n m),
-    _bst_to_bst3_retraction n m (_bst_to_bst3 n m b) =
+    _bst_to_bst3_retraction_adjoint n m (_bst_to_bst3 n m b) =
     f_equal (_bst_to_bst3 n m) (_bst_to_bst3_section n m b).
 Proof.
   exact _bst_to_bst3_adjunction.
@@ -1655,7 +1655,7 @@ Qed.
 
 Theorem test_adjunction_19:
   forall (A : Type) (tr : bintree A),
-    orn_bintree_bintreeV2_retraction A (orn_bintree_bintreeV2 A tr) =
+    orn_bintree_bintreeV2_retraction_adjoint A (orn_bintree_bintreeV2 A tr) =
     f_equal (orn_bintree_bintreeV2 A) (orn_bintree_bintreeV2_section A tr).
 Proof.
   exact orn_bintree_bintreeV2_adjunction.

--- a/plugin/coq/Test.v
+++ b/plugin/coq/Test.v
@@ -64,6 +64,14 @@ Proof.
   exact orn_list_vector_retraction.
 Qed.
 
+Theorem test_adjunction:
+  forall (A : Type) (l : list A),
+    orn_list_vector_retraction A (orn_list_vector A l) =
+    f_equal (orn_list_vector A) (orn_list_vector_section A l).
+Proof.
+  exact orn_list_vector_adjunction.
+Qed.
+
 (* --- Test auto-generated ornament name --- *)
 
 Find ornament list vector.
@@ -115,6 +123,14 @@ Theorem test_retraction_auto:
     list_to_vector A (list_to_vector_inv A v) = v.
 Proof.
   exact list_to_vector_retraction.
+Qed.
+
+Theorem test_adjunction_auto:
+  forall (A : Type) (l : list A),
+    list_to_vector_retraction A (list_to_vector A l) =
+    f_equal (list_to_vector A) (list_to_vector_section A l).
+Proof.
+  exact list_to_vector_adjunction.
 Qed.
 
 (* --- Lists and "flectors" --- *)
@@ -296,6 +312,14 @@ Proof.
   exact orn_rev_list_rev_vector_retraction.
 Qed.
 
+Theorem test_adjunction_2:
+  forall (A : Type) (l : rev_list A),
+    orn_rev_list_rev_vector_retraction A (orn_rev_list_rev_vector A l) =
+    f_equal (orn_rev_list_rev_vector A) (orn_rev_list_rev_vector_section A l).
+Proof.
+  exact orn_rev_list_rev_vector_adjunction.
+Qed.
+
 (* --- Binary Trees and Indexed Binary Trees --- *)
 
 Inductive bintree (A : Type) : Type :=
@@ -374,6 +398,14 @@ Proof.
   exact orn_bintree_bintreeV_retraction.
 Qed.
 
+Theorem test_adjunction_3:
+  forall (A : Type) (tr : bintree A),
+    orn_bintree_bintreeV_retraction A (orn_bintree_bintreeV A tr) =
+    f_equal (orn_bintree_bintreeV A) (orn_bintree_bintreeV_section A tr).
+Proof.
+  exact orn_bintree_bintreeV_adjunction.
+Qed.
+
 (* --- Lists of values of two types (making sure parameter logic works) --- *)
 
 Inductive list2 (A : Type) (B : Type) : Type :=
@@ -448,6 +480,14 @@ Proof.
   exact orn_list2_vector2_retraction.
 Qed.
 
+Theorem test_adjunction_4:
+  forall (A B : Type) (l : list2 A B),
+    orn_list2_vector2_retraction A B (orn_list2_vector2 A B l) =
+    f_equal (orn_list2_vector2 A B) (orn_list2_vector2_section A B l).
+Proof.
+  exact orn_list2_vector2_adjunction.
+Qed.
+
 (* --- Adding a nat index to a nat list --- *)
 
 Inductive nat_list : Type :=
@@ -518,6 +558,14 @@ Theorem test_retraction_5:
     orn_natlist_natvector (orn_natlist_natvector_inv v) = v.
 Proof.
   exact orn_natlist_natvector_retraction.
+Qed.
+
+Theorem test_adjunction_5:
+  forall (l : nat_list),
+    orn_natlist_natvector_retraction (orn_natlist_natvector l) =
+    f_equal orn_natlist_natvector (orn_natlist_natvector_section l).
+Proof.
+  exact orn_natlist_natvector_adjunction.
 Qed.
 
 (* --- BintreeV with nats in reverse order --- *)
@@ -592,6 +640,14 @@ Proof.
   exact orn_bintree_bintreeV_rev_retraction.
 Qed.
 
+Theorem test_adjunction_6:
+  forall (A : Type) (tr : bintree A),
+    orn_bintree_bintreeV_rev_retraction A (orn_bintree_bintreeV_rev A tr) =
+    f_equal (orn_bintree_bintreeV_rev A) (orn_bintree_bintreeV_rev_section A tr).
+Proof.
+  exact orn_bintree_bintreeV_rev_adjunction.
+Qed.
+
 (* --- Adding an index whose type that matches an already existing index --- *)
 
 Inductive doublevector (A : Type) : nat -> nat -> Type :=
@@ -664,6 +720,14 @@ Proof.
   exact orn_vector_doublevector_retraction.
 Qed.
 
+Theorem test_adjunction_7:
+  forall (A : Type) (n : nat) (v : vector A n),
+    orn_vector_doublevector_retraction A n (orn_vector_doublevector A n v) =
+    f_equal (orn_vector_doublevector A n) (orn_vector_doublevector_section A n v).
+Proof.
+  exact orn_vector_doublevector_adjunction.
+Qed.
+
 (* --- Same as above, but switch the position we change --- *)
 
 Inductive doublevector2 (A : Type) : nat -> nat -> Type :=
@@ -724,6 +788,14 @@ Theorem test_retraction_8:
     orn_vector_doublevector2 A n (orn_vector_doublevector2_inv A n v) = v.
 Proof.
   exact orn_vector_doublevector2_retraction.
+Qed.
+
+Theorem test_adjunction_8:
+  forall (A : Type) (n : nat) (v : vector A n),
+    orn_vector_doublevector2_retraction A n (orn_vector_doublevector2 A n v) =
+    f_equal (orn_vector_doublevector2 A n) (orn_vector_doublevector2_section A n v).
+Proof.
+  exact orn_vector_doublevector2_adjunction.
 Qed.
 
 (* --- Same as above, but with an identical index --- *)
@@ -798,6 +870,15 @@ Proof.
   exact orn_vector_doublevector3_retraction.
 Qed.
 
+Theorem test_adjunction_9:
+  forall (A : Type) (n : nat) (v : vector A n),
+    orn_vector_doublevector3_retraction A n (orn_vector_doublevector3 A n v) =
+    f_equal (orn_vector_doublevector3 A n) (orn_vector_doublevector3_section A n v).
+Proof.
+  exact orn_vector_doublevector3_adjunction.
+Qed.
+
+
 (* --- What if we change a base case index? --- *)
 
 Inductive doublevector4 (A : Type) : nat -> nat -> Type :=
@@ -868,6 +949,14 @@ Theorem test_retraction_10:
     orn_vector_doublevector4 A n (orn_vector_doublevector4_inv A n v) = v.
 Proof.
   exact orn_vector_doublevector4_retraction.
+Qed.
+
+Theorem test_adjunction_10:
+  forall (A : Type) (n : nat) (v : vector A n),
+    orn_vector_doublevector4_retraction A n (orn_vector_doublevector4 A n v) =
+    f_equal (orn_vector_doublevector4 A n) (orn_vector_doublevector4_section A n v).
+Proof.
+  exact orn_vector_doublevector4_adjunction.
 Qed.
 
 (* --- Indices that are computed from existing hypotheses --- *)
@@ -941,6 +1030,14 @@ Proof.
   exact orn_natlist_hdnatlist_retraction.
 Qed.
 
+Theorem test_adjunction_11:
+  forall (nl : nat_list),
+    orn_natlist_hdnatlist_retraction (orn_natlist_hdnatlist nl) =
+    f_equal orn_natlist_hdnatlist (orn_natlist_hdnatlist_section nl).
+Proof.
+  exact orn_natlist_hdnatlist_adjunction.
+Qed.
+
 (* --- Indices that depend on parameters --- *)
 
 Inductive hd_list (A : Type) : option A -> Type :=
@@ -1002,6 +1099,14 @@ Theorem test_retraction_12:
     orn_list_hdlist A (orn_list_hdlist_inv A l) = l.
 Proof.
   exact orn_list_hdlist_retraction.
+Qed.
+
+Theorem test_adjunction_12:
+  forall (A : Type) (l : list A),
+    orn_list_hdlist_retraction A (orn_list_hdlist A l) =
+    f_equal (orn_list_hdlist A) (orn_list_hdlist_section A l).
+Proof.
+  exact orn_list_hdlist_adjunction.
 Qed.
 
 (* --- Indices that depend on prior indices --- *)
@@ -1081,6 +1186,14 @@ Proof.
   exact orn_listalt_hdlistalt_retraction.
 Qed.
 
+Theorem test_adjunction_13:
+  forall (A : Type) (l : list_alt A),
+    orn_listalt_hdlistalt_retraction A (orn_listalt_hdlistalt A l) =
+    f_equal (orn_listalt_hdlistalt A) (orn_listalt_hdlistalt_section A l).
+Proof.
+  exact orn_listalt_hdlistalt_adjunction.
+Qed.
+
 (* --- Indexing by the old type, but without making it fin-like --- *)
 
 Inductive nat_nat : nat -> Type :=
@@ -1149,8 +1262,16 @@ Proof.
   exact orn_nat_natnat_retraction.
 Qed.
 
+Theorem test_adjunction_14:
+  forall (n : nat),
+    orn_nat_natnat_retraction (orn_nat_natnat n) =
+    f_equal orn_nat_natnat (orn_nat_natnat_section n).
+Proof.
+  exact orn_nat_natnat_adjunction.
+Qed.
+
 (* --- Regression of bug in more complicated index identification algorithm --- *)
-  
+
 (*
  * Minimal test case
  *)
@@ -1215,10 +1336,18 @@ Proof.
   exact orn_vector_doublevector5_retraction.
 Qed.
 
+Theorem test_adjunction_15:
+  forall (A : Type) (n : nat) (v : vector A n),
+    orn_vector_doublevector5_retraction A n (orn_vector_doublevector5 A n v) =
+    f_equal (orn_vector_doublevector5 A n) (orn_vector_doublevector5_section A n v).
+Proof.
+  exact orn_vector_doublevector5_adjunction.
+Qed.
+
 (* --- More regression --- *)
 
 (*
- * From case study, made ambiguous so the more complex algorithm runs, 
+ * From case study, made ambiguous so the more complex algorithm runs,
  * and then simplified
  *)
 
@@ -1229,8 +1358,8 @@ Inductive _bst : nat -> nat -> Type :=
 | _Leaf (val : nat) : _bst val val.
 
 Definition inv (ord_l ord_r : nat) (max_l val min_r : nat) : nat :=
-  ord_l * 
-  ord_r * 
+  ord_l *
+  ord_r *
   (if Nat.ltb max_l val then 1 else 0) *
   (if Nat.ltb val min_r then 1 else 0).
 
@@ -1244,15 +1373,15 @@ Inductive bst : nat -> nat -> nat -> Type :=
 Find ornament _bst bst.
 
 Definition is_bst (n m : nat) (b : _bst n m) : nat :=
-  _bst_rect 
+  _bst_rect
     (fun _ _ _  => nat)
-    (fun (min_l min_r max_l max_r val : nat) 
+    (fun (min_l min_r max_l max_r val : nat)
          (left : _bst min_l max_l) (IHl : nat)
          (right : _bst min_r max_r) (IHr : nat) =>
-      inv IHl IHr max_l val min_r) 
-    (fun _ : nat => 1) 
+      inv IHl IHr max_l val min_r)
+    (fun _ : nat => 1)
     n
-    m 
+    m
     b.
 
 Definition packed_bst (n m : nat) :=
@@ -1305,6 +1434,14 @@ Theorem test_retraction_16:
     _bst_to_bst n m (_bst_to_bst_inv n m b) = b.
 Proof.
   exact _bst_to_bst_retraction.
+Qed.
+
+Theorem test_adjunction_16:
+  forall (n m : nat) (b : _bst n m),
+    _bst_to_bst_retraction n m (_bst_to_bst n m b) =
+    f_equal (_bst_to_bst n m) (_bst_to_bst_section n m b).
+Proof.
+  exact _bst_to_bst_adjunction.
 Qed.
 
 (* --- Make sure moving the hypotheses around works too --- *)
@@ -1370,13 +1507,21 @@ Proof.
   exact _bst_to_bst2_retraction.
 Qed.
 
+Theorem test_adjunction_17:
+  forall (n m : nat) (b : _bst n m),
+    _bst_to_bst2_retraction n m (_bst_to_bst2 n m b) =
+    f_equal (_bst_to_bst2 n m) (_bst_to_bst2_section n m b).
+Proof.
+  exact _bst_to_bst2_adjunction.
+Qed.
+
 (* --- Test moving around the index location --- *)
 
 Inductive bst3 : nat -> nat -> nat -> Type :=
 | Branch3 (ord_l : nat) (min_l min_r : nat) (max_l max_r : nat)
          (val : nat)
          (left : bst3 min_l ord_l max_l) (ord_r : nat) (right : bst3 min_r ord_r max_r)
-      : bst3 min_l (inv ord_l ord_r max_l val min_r) max_r 
+      : bst3 min_l (inv ord_l ord_r max_l val min_r) max_r
 | Leaf3 (val : nat) : bst3 val 1 val.
 
 Find ornament _bst bst3.
@@ -1433,17 +1578,25 @@ Proof.
   exact _bst_to_bst3_retraction.
 Qed.
 
+Theorem test_adjunction_18:
+  forall (n m : nat) (b : _bst n m),
+    _bst_to_bst3_retraction n m (_bst_to_bst3 n m b) =
+    f_equal (_bst_to_bst3 n m) (_bst_to_bst3_section n m b).
+Proof.
+  exact _bst_to_bst3_adjunction.
+Qed.
+
 (* --- Binary trees with changed hypothesis order --- *)
 
 Inductive bintreeV2 (A : Type) : nat -> Type :=
 | leafV2:
     bintreeV2 A 0
 | nodeV2 :
-    forall (n : nat), 
-      bintreeV2 A n -> 
-      A -> 
-      forall (m : nat), 
-        bintreeV2 A m -> 
+    forall (n : nat),
+      bintreeV2 A n ->
+      A ->
+      forall (m : nat),
+        bintreeV2 A m ->
         bintreeV2 A (S (n + m)).
 
 Definition packed_bintreeV2 (T : Type) :=
@@ -1458,7 +1611,7 @@ Proof.
   intros. reflexivity.
 Qed.
 
-Theorem test_orn_19: 
+Theorem test_orn_19:
   forall (A : Type) (tr : bintree A),
     packed_bintreeV2 A.
 Proof.
@@ -1500,6 +1653,14 @@ Proof.
   exact orn_bintree_bintreeV2_retraction.
 Qed.
 
+Theorem test_adjunction_19:
+  forall (A : Type) (tr : bintree A),
+    orn_bintree_bintreeV2_retraction A (orn_bintree_bintreeV2 A tr) =
+    f_equal (orn_bintree_bintreeV2 A) (orn_bintree_bintreeV2_section A tr).
+Proof.
+  exact orn_bintree_bintreeV2_adjunction.
+Qed.
+
 (* (* --- TODO Index already existed in the old constructor, but wasn't used --- *) *)
 
 (* (* --- TODO Index already existed in the old constructor, but was used differently --- *) *)
@@ -1507,4 +1668,3 @@ Qed.
 (* (* --- TODO weirder indexes --- *) *)
 
 (* (* --- TODO examples from notebook etc --- *) *)
-

--- a/plugin/coq/examples/Example.v
+++ b/plugin/coq/examples/Example.v
@@ -74,6 +74,11 @@ Print ltv_inv.
  * See Search.v for a detailed walkthrough of the output.
  *)
 
+Check ltv_section.
+Check ltv_retraction.
+Check ltv_adjunction.
+Definition ltv_adjunction' : forall A x, ltv_retraction A (ltv A x) = f_equal (ltv A) (ltv_section A x) := ltv_adjunction.
+
 (* --- Lift --- *)
 
 Lift list vector in hs_to_coq.zip as zipV_p.
@@ -225,13 +230,13 @@ Definition BVand' {n : nat} (v1 : vector bool n) (v2 : vector bool n) : vector b
 
 Lemma refold_section:
   forall T t l,
-    ltv_section T (t :: l) = 
-    eq_sym 
-      (eq_ind 
-        l 
-        (fun l0 => t :: l = t :: l0) 
-        (erefl (t :: l)) 
-        (ltv_inv T (ltv T l)) 
+    ltv_section T (t :: l) =
+    eq_sym
+      (eq_ind
+        l
+        (fun l0 => t :: l = t :: l0)
+        (erefl (t :: l))
+        (ltv_inv T (ltv T l))
         (eq_sym (ltv_section T l))).
 Proof.
   intros. unfold ltv_section. rewrite eq_sym_involutive. f_equal.
@@ -239,44 +244,15 @@ Qed.
 
 Lemma refold_retraction:
   forall A a x,
-    ltv_retraction A (existT _ (S (ltv_index A x)) (consV (ltv_index A x) a (projT2 (ltv A x)))) =
-    sigT_rect 
-      (fun (H : sigT (vector A)) => ltv A (ltv_inv A (existT _ _ (consV (projT1 H) a (projT2 H)))) = existT _ _ (consV (projT1 H) a (projT2 H))) 
-      (fun (n : nat) (v : vector A n) => eq_sym (eq_ind _ (fun v1 => existT (vector A) (S n) (consV n a v) = existT _ (S (projT1 v1)) (consV (projT1 v1) a (projT2 v1))) 
-        (erefl (existT _ (S (projT1 (existT _ n v))) (consV n a v))) 
-        (existT _ (projT1 (ltv A (ltv_inv A (existT _ n v)))) 
-        (projT2 (ltv A (ltv_inv A (existT _ n v))))) 
-        (eq_sym (ltv_retraction A (existT _ n v))))) 
+    ltv_retraction0 A (existT _ (S (ltv_index A x)) (consV (ltv_index A x) a (projT2 (ltv A x)))) =
+    sigT_rect
+      (fun (H : sigT (vector A)) => ltv A (ltv_inv A (existT _ _ (consV (projT1 H) a (projT2 H)))) = existT _ _ (consV (projT1 H) a (projT2 H)))
+      (fun (n : nat) (v : vector A n) => eq_sym (eq_ind _ (fun v1 => existT (vector A) (S n) (consV n a v) = existT _ (S (projT1 v1)) (consV (projT1 v1) a (projT2 v1)))
+        (erefl (existT _ (S (projT1 (existT _ n v))) (consV n a v)))
+        (existT _ (projT1 (ltv A (ltv_inv A (existT _ n v))))
+        (projT2 (ltv A (ltv_inv A (existT _ n v)))))
+        (eq_sym (ltv_retraction0 A (existT _ n v)))))
       (ltv A x).
 Proof.
-  intros. unfold ltv_retraction. simpl. rewrite eq_sym_involutive. f_equal.
+  intros. unfold ltv_retraction0. simpl. rewrite eq_sym_involutive. f_equal.
 Qed.
-
-Check eq_ind.
-
-Lemma ltv_adjunction : 
-  forall A x, 
-    ltv_retraction A (ltv A x) = 
-    f_equal (ltv A) (ltv_section A x).
-Proof.
-  intros A x. induction x.
-  - auto.
-  - rewrite refold_section. rewrite refold_retraction.
-    change (ltv A (a :: x)) with 
-           (existT _ 
-             (S (projT1 (ltv A x))) 
-             (consV (projT1 (ltv A x)) a (projT2 (ltv A x)))).
-    change (ltv A x) with (existT _ (projT1 (ltv A x)) (projT2 (ltv A x))).
-    change (projT1 (ltv A x)) with (ltv_index A x) in *.
-    unfold sigT_rect.
-    rewrite IHx.
-    rewrite <- eq_sym_map_distr.
-    f_equal.
-    rewrite eq_sym_map_distr.
-    change (projT1 (ltv A (ltv_inv A (existT [eta vector A] (ltv_index A x) (projT2 (ltv A x))))))
-      with (ltv_index A (ltv_inv A (existT [eta vector A] (ltv_index A x) (projT2 (ltv A x))))).
-    change (projT1 (existT [eta vector A] (ltv_index A x) (projT2 (ltv A x))))
-     with (ltv_index A x).
-Abort.
-
-

--- a/plugin/coq/examples/Example.v
+++ b/plugin/coq/examples/Example.v
@@ -74,9 +74,9 @@ Print ltv_inv.
  * See Search.v for a detailed walkthrough of the output.
  *)
 
-Check ltv_section.
-Check ltv_retraction.
-Check ltv_adjunction.
+(*
+ * State adjunction with a slightly nicer type.
+ *)
 Definition ltv_adjunction' : forall A x, ltv_retraction A (ltv A x) = f_equal (ltv A) (ltv_section A x) := ltv_adjunction.
 
 (* --- Lift --- *)
@@ -226,33 +226,3 @@ Defined.
 
 Definition BVand' {n : nat} (v1 : vector bool n) (v2 : vector bool n) : vector bool n :=
   zip_withV_uf andb v1 v2.
-
-
-Lemma refold_section:
-  forall T t l,
-    ltv_section T (t :: l) =
-    eq_sym
-      (eq_ind
-        l
-        (fun l0 => t :: l = t :: l0)
-        (erefl (t :: l))
-        (ltv_inv T (ltv T l))
-        (eq_sym (ltv_section T l))).
-Proof.
-  intros. unfold ltv_section. rewrite eq_sym_involutive. f_equal.
-Qed.
-
-Lemma refold_retraction:
-  forall A a x,
-    ltv_retraction0 A (existT _ (S (ltv_index A x)) (consV (ltv_index A x) a (projT2 (ltv A x)))) =
-    sigT_rect
-      (fun (H : sigT (vector A)) => ltv A (ltv_inv A (existT _ _ (consV (projT1 H) a (projT2 H)))) = existT _ _ (consV (projT1 H) a (projT2 H)))
-      (fun (n : nat) (v : vector A n) => eq_sym (eq_ind _ (fun v1 => existT (vector A) (S n) (consV n a v) = existT _ (S (projT1 v1)) (consV (projT1 v1) a (projT2 v1)))
-        (erefl (existT _ (S (projT1 (existT _ n v))) (consV n a v)))
-        (existT _ (projT1 (ltv A (ltv_inv A (existT _ n v))))
-        (projT2 (ltv A (ltv_inv A (existT _ n v)))))
-        (eq_sym (ltv_retraction0 A (existT _ n v)))))
-      (ltv A x).
-Proof.
-  intros. unfold ltv_retraction0. simpl. rewrite eq_sym_involutive. f_equal.
-Qed.

--- a/plugin/coq/examples/Example.v
+++ b/plugin/coq/examples/Example.v
@@ -223,37 +223,60 @@ Definition BVand' {n : nat} (v1 : vector bool n) (v2 : vector bool n) : vector b
   zip_withV_uf andb v1 v2.
 
 
-(* Type of adjunction for ltv. *)
-Check (forall A x, ltv_retraction A (ltv A x) = f_equal (ltv A) (ltv_section A x)).
+Lemma refold_section:
+  forall T t l,
+    ltv_section T (t :: l) = 
+    eq_sym 
+      (eq_ind 
+        l 
+        (fun l0 => t :: l = t :: l0) 
+        (erefl (t :: l)) 
+        (ltv_inv T (ltv T l)) 
+        (eq_sym (ltv_section T l))).
+Proof.
+  intros. unfold ltv_section. rewrite eq_sym_involutive. f_equal.
+Qed.
 
-Lemma ltv_adjunction : forall A x, ltv_retraction A (ltv A x) = f_equal (ltv A) (ltv_section A x).
+Lemma refold_retraction:
+  forall A a x,
+    ltv_retraction A (existT _ (S (ltv_index A x)) (consV (ltv_index A x) a (projT2 (ltv A x)))) =
+    sigT_rect 
+      (fun (H : sigT (vector A)) => ltv A (ltv_inv A (existT _ _ (consV (projT1 H) a (projT2 H)))) = existT _ _ (consV (projT1 H) a (projT2 H))) 
+      (fun (n : nat) (v : vector A n) => eq_sym (eq_ind _ (fun v1 => existT (vector A) (S n) (consV n a v) = existT _ (S (projT1 v1)) (consV (projT1 v1) a (projT2 v1))) 
+        (erefl (existT _ (S (projT1 (existT _ n v))) (consV n a v))) 
+        (existT _ (projT1 (ltv A (ltv_inv A (existT _ n v)))) 
+        (projT2 (ltv A (ltv_inv A (existT _ n v))))) 
+        (eq_sym (ltv_retraction A (existT _ n v))))) 
+      (ltv A x).
+Proof.
+  intros. unfold ltv_retraction. simpl. rewrite eq_sym_involutive. f_equal.
+Qed.
+
+Check eq_ind.
+
+Lemma ltv_adjunction : 
+  forall A x, 
+    ltv_retraction A (ltv A x) = 
+    f_equal (ltv A) (ltv_section A x).
 Proof.
   intros A x. induction x.
-  - simpl. reflexivity.
-  - change (ltv A (a :: x)) with (existT _ (S (projT1 (ltv A x))) (consV (projT1 (ltv A x)) a (projT2 (ltv A x)))).
-  (*  change (projT1 (ltv A x)) with (ltv_index A x).*)
-    Print ltv_section.
-    assert (ltv_section A (a :: x) = eq_sym (eq_ind x (fun H0 => a :: x = a :: H0) (erefl (a :: x)) (ltv_inv A (ltv A x)) (eq_sym (ltv_section A x)))).
-    + unfold ltv_section. f_equal. simpl. f_equal.
-      rewrite eq_sym_involutive.
-      auto.
-    + rewrite H.
-      Print ltv_retraction.
-      assert (ltv_retraction A (existT _ (S (ltv_index A x)) (consV (ltv_index A x) a (projT2 (ltv A x)))) =
-              sigT_rect (fun (H : sigT (vector A)) => ltv A (ltv_inv A (existT _ _ (consV (projT1 H) a (projT2 H)))) = existT _ _ (consV (projT1 H) a (projT2 H))) (fun (n : nat) (v : vector A n) => eq_sym (eq_ind _ (fun v1 => existT (vector A) (S n) (consV n a v) = existT _ (S (projT1 v1)) (consV (projT1 v1) a (projT2 v1))) (erefl (existT _ (S (projT1 (existT _ n v))) (consV n a v))) (existT _ (projT1 (ltv A (ltv_inv A (existT _ n v)))) (projT2 (ltv A (ltv_inv A (existT _ n v))))) (eq_sym (ltv_retraction A (existT _ n v))))) (existT _ (projT1 (ltv A x)) (projT2 (ltv A x)))).
-      * assert (ltv A x = existT _ (projT1 (ltv A x)) (projT2 (ltv A x))).
-        ** auto.
-        ** rewrite H0.
-           ciompute.
-      * rewrite H0.  destruct (ltv A x). rewrite ltv_coh.
+  - auto.
+  - rewrite refold_section. rewrite refold_retraction.
+    change (ltv A (a :: x)) with 
+           (existT _ 
+             (S (projT1 (ltv A x))) 
+             (consV (projT1 (ltv A x)) a (projT2 (ltv A x)))).
+    change (ltv A x) with (existT _ (projT1 (ltv A x)) (projT2 (ltv A x))).
+    change (projT1 (ltv A x)) with (ltv_index A x) in *.
+    unfold sigT_rect.
+    rewrite IHx.
+    rewrite <- eq_sym_map_distr.
+    f_equal.
+    rewrite eq_sym_map_distr.
+    change (projT1 (ltv A (ltv_inv A (existT [eta vector A] (ltv_index A x) (projT2 (ltv A x))))))
+      with (ltv_index A (ltv_inv A (existT [eta vector A] (ltv_index A x) (projT2 (ltv A x))))).
+    change (projT1 (existT [eta vector A] (ltv_index A x) (projT2 (ltv A x))))
+     with (ltv_index A x).
+Abort.
 
-        change (projT1 (ltv A (ltv_inv A (existT (vector A) n)))) simpl. unfold ltv_retraction in IHx. rewrite IHx.
-        compute in *. rewrite IHx. iauto.
 
-        assert (ltv A x = existT _ (projT1 (ltv A x)) (projT2 (ltv A x))).
-        ** auto.
-        ** rewrite <- H1.
-        assert (ltv_retraction A (ltv A x) = ltv_retraction A
-
-        remember (ltv A x) as v.
-      * unfold f_equal in *.

--- a/plugin/coq/examples/Example.v
+++ b/plugin/coq/examples/Example.v
@@ -74,11 +74,6 @@ Print ltv_inv.
  * See Search.v for a detailed walkthrough of the output.
  *)
 
-(*
- * State adjunction with a slightly nicer type.
- *)
-Definition ltv_adjunction' : forall A x, ltv_retraction A (ltv A x) = f_equal (ltv A) (ltv_section A x) := ltv_adjunction.
-
 (* --- Lift --- *)
 
 Lift list vector in hs_to_coq.zip as zipV_p.

--- a/plugin/coq/examples/Example.v
+++ b/plugin/coq/examples/Example.v
@@ -68,7 +68,7 @@ Find ornament list vector as ltv.
 Print ltv.
 Print ltv_inv.
 
-(* 
+(*
  * As mentioned in the paper, these form an equivalence.
  * This is proven automatically by the prove equivalence option.
  * See Search.v for a detailed walkthrough of the output.
@@ -108,7 +108,7 @@ Eval compute in (zipV (consV 0 2 (nilV nat)) (consV 0 1 (nilV nat))).
 
 (*
  * However, this type isn't actually what we want. The user-friendly
- * versions of the functions are simple to recover. 
+ * versions of the functions are simple to recover.
  *
  * First, we will prove the indexer is what we want. To do this, we can
  * simply prove this over the indexer of the original list functions,
@@ -165,7 +165,7 @@ Definition zip_withV_uf {A} {B} {C} (f : A -> B -> C) {n} (v1 : vector A n) (v2 
 (*
  * For proofs, we have to deal with dependent equality.
  * This is more challenging. Essentially, we have to relate
- * our other equalities. 
+ * our other equalities.
  *
  * In the case of nat, the easiest
  * way to do this is to use the fact that nats form an hset
@@ -190,7 +190,7 @@ Defined.
  * to show that we do not duplicate equalities (credit to Jason Gross).
  * This holds for all algebraic ornaments, not just those for which UIP holds
  * on the index type.
- * 
+ *
  * See https://github.com/uwplse/ornamental-search/issues/39 for the latest thoughts
  * on this, and please check the latest version of this file in master to see
  * if we have implemented this if you are reading this in a release.
@@ -205,13 +205,13 @@ Lemma zip_with_is_zipV_uf :
 Proof.
   intros. unfold zip_withV_uf, zipV_uf, zipV.
   pose proof (eq_sigT_snd (eq_dep_eq_sigT_red _ _ _ _ _ _ (zip_with_is_zipV v1 v2))).
-  simpl in *. rewrite <- H. rewrite zip_with_is_zipV_uf_aux. 
+  simpl in *. rewrite <- H. rewrite zip_with_is_zipV_uf_aux.
   apply eq_trans_rew_distr.
 Defined.
 
 (*
- * Note: For this particular example, interestingly, doing these by hand 
- * without DEVOID, it's possible to construct functions such that the proof 
+ * Note: For this particular example, interestingly, doing these by hand
+ * without DEVOID, it's possible to construct functions such that the proof
  * of zip_with_is_zipV_uf goes through by reflexivity. However, these
  * are not the analogues of the functions included in the hs_to_coq module
  * (note that the proof using reflexivity does not work for them either).
@@ -222,3 +222,38 @@ Defined.
 Definition BVand' {n : nat} (v1 : vector bool n) (v2 : vector bool n) : vector bool n :=
   zip_withV_uf andb v1 v2.
 
+
+(* Type of adjunction for ltv. *)
+Check (forall A x, ltv_retraction A (ltv A x) = f_equal (ltv A) (ltv_section A x)).
+
+Lemma ltv_adjunction : forall A x, ltv_retraction A (ltv A x) = f_equal (ltv A) (ltv_section A x).
+Proof.
+  intros A x. induction x.
+  - simpl. reflexivity.
+  - change (ltv A (a :: x)) with (existT _ (S (projT1 (ltv A x))) (consV (projT1 (ltv A x)) a (projT2 (ltv A x)))).
+  (*  change (projT1 (ltv A x)) with (ltv_index A x).*)
+    Print ltv_section.
+    assert (ltv_section A (a :: x) = eq_sym (eq_ind x (fun H0 => a :: x = a :: H0) (erefl (a :: x)) (ltv_inv A (ltv A x)) (eq_sym (ltv_section A x)))).
+    + unfold ltv_section. f_equal. simpl. f_equal.
+      rewrite eq_sym_involutive.
+      auto.
+    + rewrite H.
+      Print ltv_retraction.
+      assert (ltv_retraction A (existT _ (S (ltv_index A x)) (consV (ltv_index A x) a (projT2 (ltv A x)))) =
+              sigT_rect (fun (H : sigT (vector A)) => ltv A (ltv_inv A (existT _ _ (consV (projT1 H) a (projT2 H)))) = existT _ _ (consV (projT1 H) a (projT2 H))) (fun (n : nat) (v : vector A n) => eq_sym (eq_ind _ (fun v1 => existT (vector A) (S n) (consV n a v) = existT _ (S (projT1 v1)) (consV (projT1 v1) a (projT2 v1))) (erefl (existT _ (S (projT1 (existT _ n v))) (consV n a v))) (existT _ (projT1 (ltv A (ltv_inv A (existT _ n v)))) (projT2 (ltv A (ltv_inv A (existT _ n v))))) (eq_sym (ltv_retraction A (existT _ n v))))) (existT _ (projT1 (ltv A x)) (projT2 (ltv A x)))).
+      * assert (ltv A x = existT _ (projT1 (ltv A x)) (projT2 (ltv A x))).
+        ** auto.
+        ** rewrite H0.
+           ciompute.
+      * rewrite H0.  destruct (ltv A x). rewrite ltv_coh.
+
+        change (projT1 (ltv A (ltv_inv A (existT (vector A) n)))) simpl. unfold ltv_retraction in IHx. rewrite IHx.
+        compute in *. rewrite IHx. iauto.
+
+        assert (ltv A x = existT _ (projT1 (ltv A x)) (projT2 (ltv A x))).
+        ** auto.
+        ** rewrite <- H1.
+        assert (ltv_retraction A (ltv A x) = ltv_retraction A
+
+        remember (ltv A x) as v.
+      * unfold f_equal in *.

--- a/plugin/coq/examples/Search.v
+++ b/plugin/coq/examples/Search.v
@@ -100,10 +100,9 @@ Proof.
   exact ltv_retraction.
 Qed.
 
-  Check ltv_adjunction.
 Theorem adjunction:
   forall {T : Type} (l : list T),
-    ltv_retraction T (ltv T l) = f_equal (ltv T) (ltv_section T l).
+    ltv_retraction_adjoint T (ltv T l) = f_equal (ltv T) (ltv_section T l).
 Proof.
   exact ltv_adjunction.
 Qed.

--- a/plugin/coq/examples/Search.v
+++ b/plugin/coq/examples/Search.v
@@ -26,7 +26,7 @@ Find ornament list vector as ltv.
  *)
 Print ltv_index.
 
-(* 
+(*
  * Let's call this the indexer:
  *)
 Notation indexer l := (ltv_index _ l).
@@ -48,7 +48,7 @@ Qed.
  *)
 Print ltv.
 
-(* 
+(*
  * Let's call this promote:
  *)
 Notation promote l := (ltv _ l).
@@ -60,7 +60,7 @@ Notation promote l := (ltv _ l).
  *)
 Print ltv_inv.
 
-(* 
+(*
  * Let's call this forget
  *)
 Notation forget l := (ltv_inv _ l).
@@ -69,7 +69,7 @@ Notation forget l := (ltv_inv _ l).
 
 (*
  * Since we set the "prove coherence" and "prove equivalence" options,
- * DEVOID generated coherence, section, and retraction proofs. Here I 
+ * DEVOID generated coherence, section, and retraction proofs. Here I
  * simply restate them and show that the generated terms are correct.
  * These automatically generated proofs show that the components DEVOID
  * found form the ornamental promotion isomorphism between lists and vectors.
@@ -98,4 +98,12 @@ Theorem retraction:
     promote (forget v) = v.
 Proof.
   exact ltv_retraction.
+Qed.
+
+  Check ltv_adjunction.
+Theorem adjunction:
+  forall {T : Type} (l : list T),
+    ltv_retraction T (ltv T l) = f_equal (ltv T) (ltv_section T l).
+Proof.
+  exact ltv_adjunction.
 Qed.

--- a/plugin/src/automation/equivalence.ml
+++ b/plugin/src/automation/equivalence.ml
@@ -284,6 +284,10 @@ let quantify_pre_adjunction env evd { orn; sect; retr0 } =
 
 (*
  * Augment the initial retraction proof in order to prove adjunction.
+ *
+ * The generic proof of adjunction from the HoTT book relies critically on this
+ * step; wrapping the proof term for retraction in a clever way (formalized in
+ * `fg_id'`) makes a later equality of equality proofs true definitionally.
  *)
 let adjointify_retraction env evd pre_adj =
   let (evd, adjointifier) =
@@ -294,9 +298,6 @@ let adjointify_retraction env evd pre_adj =
 
 (*
  * Prove adjunction.
- *
- * TODO: Return a companion type expressed in terms of the augmented retraction
- * proof.
  *)
 let prove_adjunction env evd pre_adj =
   let (evd, adjunctifier) =

--- a/plugin/src/automation/equivalence.mli
+++ b/plugin/src/automation/equivalence.mli
@@ -21,13 +21,14 @@ type pre_adjoint = {
 
 (*
  * Augment the initial retraction proof in order to prove adjunction.
+ *
+ * The generic proof of adjunction from the HoTT book relies critically on this
+ * step; wrapping the proof term for retraction in a clever way (formalized in
+ * `fg_id'`) makes a later equality of equality proofs true definitionally.
  *)
 val adjointify_retraction : env -> evar_map -> pre_adjoint -> evar_map * constr
 
 (*
  * Prove adjunction.
- *
- * TODO: Return a companion type expressed in terms of the augmented retraction
- * proof.
  *)
 val prove_adjunction : env -> evar_map -> pre_adjoint -> evar_map * constr

--- a/plugin/src/automation/equivalence.mli
+++ b/plugin/src/automation/equivalence.mli
@@ -1,4 +1,5 @@
 open Constr
+open Names
 open Environ
 open Evd
 open Lifting
@@ -11,3 +12,22 @@ open Lifting
  * (Don't return the types, since Coq can infer them without issue)
  *)
 val prove_equivalence : env -> evar_map -> lifting -> (types * types)
+
+type pre_adjoint = {
+  orn : lifting;
+  sect : Constant.t;
+  retr0 : Constant.t
+}
+
+(*
+ * Augment the initial retraction proof in order to prove adjunction.
+ *)
+val adjointify_retraction : env -> evar_map -> pre_adjoint -> evar_map * constr
+
+(*
+ * Prove adjunction.
+ *
+ * TODO: Return a companion type expressed in terms of the augmented retraction
+ * proof.
+ *)
+val prove_adjunction : env -> evar_map -> pre_adjoint -> evar_map * constr

--- a/plugin/src/frontend.ml
+++ b/plugin/src/frontend.ml
@@ -53,7 +53,7 @@ let maybe_prove_equivalence n inv_n : unit =
     let l = initialize_lifting env evd promote forget in
     let (section, retraction) = prove_equivalence env evd l in
     let sect = define_proof "section" evd section in
-    let retr0 = define_proof "retraction0" evd retraction ~adjective:"pre-retraction" in
+    let retr0 = define_proof "retraction" evd retraction in
     (* This definition refers to section and retraction by name, so we grab a
      * refreshed global environment; otherwise, they would appear undefined.
      *
@@ -64,7 +64,7 @@ let maybe_prove_equivalence n inv_n : unit =
       let env = Global.env () in
       let evd = Evd.from_env env in
       let (evd, retraction) = adjointify_retraction env evd pre_adjoint in
-      define_proof "retraction" evd retraction
+      define_proof "retraction_adjoint" evd retraction ~adjective:"adjoint retraction"
     in
     (* As above, grab a refreshed global environment (with evar_map) so that all
      * the preceding constants are defined.

--- a/plugin/src/frontend.ml
+++ b/plugin/src/frontend.ml
@@ -54,6 +54,11 @@ let maybe_prove_equivalence n inv_n : unit =
     let (section, retraction) = prove_equivalence env evd l in
     let sect = define_proof "section" evd section in
     let retr0 = define_proof "retraction0" evd retraction ~adjective:"pre-retraction" in
+    (* This definition refers to section and retraction by name, so we grab a
+     * refreshed global environment; otherwise, they would appear undefined.
+     *
+     * We also instantiate a new evar_map, to synchronize with the environment.
+     *)
     let pre_adjoint = { orn = l; sect; retr0 } in
     let _ =
       let env = Global.env () in
@@ -61,6 +66,9 @@ let maybe_prove_equivalence n inv_n : unit =
       let (evd, retraction) = adjointify_retraction env evd pre_adjoint in
       define_proof "retraction" evd retraction
     in
+    (* As above, grab a refreshed global environment (with evar_map) so that all
+     * the preceding constants are defined.
+     *)
     let _ =
       let env = Global.env () in
       let evd = Evd.from_env env in

--- a/plugin/theories/Adjoint.v
+++ b/plugin/theories/Adjoint.v
@@ -1,0 +1,96 @@
+(** Credit to Jasper Hugunin (jashug) for this module. *)
+
+(* Turn a pair of inverses into an adjoint equivalence *)
+(* Proof follows the HoTT book *)
+(* Mostly, just a lot of manipulation of equality proofs *)
+
+(* Lemma 2.4.3 in HoTT book, specialized to g = id *)
+Definition commute_homotopy_id {A} {f : A -> A}
+  (f_id : forall a, f a = a) {x y : A} (p : x = y)
+  : eq_trans (f_id x) p = eq_trans (f_equal f p) (f_id y)
+  := match p in (_ = y)
+     return eq_trans (f_id x) p = eq_trans (f_equal f p) (f_id y)
+     with eq_refl => eq_sym (eq_trans_refl_l (f_id x)) end.
+
+Section adjointify.
+Context {A B} (f : A -> B) (g : B -> A).
+
+Section g_adjoint.
+Context
+  (gf_id : forall a, g (f a) = a)
+  (fg_id : forall b, f (g b) = b).
+
+Definition f_adjoint_gives_g_adjoint_pointwise
+  (b : B) (f_adjoint_at_gb : fg_id (f (g b)) = f_equal f (gf_id (g b)))
+  : gf_id (g b) = f_equal g (fg_id b)
+  := let precomposed_eq
+      : eq_trans (f_equal (fun a => g (f a)) (f_equal g (fg_id b)))
+         (gf_id (g b)) =
+        eq_trans (f_equal g (f_equal (fun b => f (g b)) (fg_id b)))
+          (f_equal g (fg_id b))
+      := eq_trans
+         (eq_sym (commute_homotopy_id gf_id (f_equal g (fg_id b))))
+         (eq_rect (f_equal g (fg_id (f (g b)))) (fun p => eq_trans p _ = _)
+          (eq_trans (eq_trans
+           (eq_sym (eq_trans_map_distr g _ _))
+           (f_equal (fun p => f_equal g p)
+            (commute_homotopy_id fg_id (fg_id b))))
+           (eq_trans_map_distr g _ _)) _
+          (eq_trans (eq_trans
+           (f_equal (fun p => f_equal g p) f_adjoint_at_gb)
+           (f_equal_compose f g _))
+           (eq_id_comm_r _ gf_id  (g b)))) in
+     match fg_id b as p
+     return
+       forall p1 p2,
+       eq_trans (f_equal _ (f_equal g p)) p1 =
+       eq_trans (f_equal g (f_equal _ p)) p2 ->
+       p1 = p2
+     with eq_refl => fun p1 p2 eq =>
+       eq_trans (eq_trans
+         (eq_sym (eq_trans_refl_l _))
+         eq)
+         (eq_trans_refl_l _)
+     end (gf_id (g b)) (f_equal g (fg_id b)) precomposed_eq.
+
+Definition f_adjoint_gives_g_adjoint
+  (f_adjoint : forall a, fg_id (f a) = f_equal f (gf_id a))
+  (b : B) : gf_id (g b) = f_equal g (fg_id b)
+  := f_adjoint_gives_g_adjoint_pointwise b (f_adjoint (g b)).
+End g_adjoint.
+
+Section correction.
+Context
+  (gf_id : forall a, g (f a) = a)
+  (fg_id : forall b, f (g b) = b).
+
+(* N.B.: The adjoint equivalence will use this instead of the given section. *)
+Definition fg_id' b : f (g b) = b
+  := eq_trans (eq_sym (fg_id (f (g b))))
+     (eq_trans (f_equal f (gf_id (g b))) (fg_id b)).
+
+Definition f_adjoint a : fg_id' (f a) = f_equal f (gf_id a)
+  := let symmetric_eq
+      : eq_trans (f_equal f (gf_id (g (f a)))) (fg_id (f a)) =
+        eq_trans (fg_id (f (g (f a)))) (f_equal f (gf_id a))
+      := eq_trans (eq_trans
+         (f_equal (fun H => eq_trans (f_equal f H) (fg_id (f a)))
+          (eq_sym (eq_id_comm_r _ gf_id a)))
+         (f_equal (fun p => eq_trans p _)
+          (eq_trans
+           (f_equal_compose (fun a => g (f a)) f _)
+           (eq_sym (f_equal_compose f (fun b => f (g b)) _)))))
+         (eq_sym (commute_homotopy_id fg_id (f_equal f (gf_id a)))) in
+     match fg_id (f (g (f a))) as p
+     return forall p', _ = eq_trans p p' -> eq_trans (eq_sym p) _ = p'
+     with eq_refl => fun p' eq =>
+       eq_trans (eq_trans_refl_l _) (eq_trans eq (eq_trans_refl_l _))
+     end _ symmetric_eq.
+
+Definition g_adjoint
+  : forall b, gf_id (g b) = f_equal g (fg_id' b)
+  := f_adjoint_gives_g_adjoint gf_id fg_id' f_adjoint.
+
+End correction.
+
+End adjointify.

--- a/plugin/theories/Adjoint.v
+++ b/plugin/theories/Adjoint.v
@@ -1,4 +1,8 @@
-(** Credit to Jasper Hugunin (jashug) for this module. *)
+(** Credit to Jasper Hugunin (jashug) for this module.
+ *
+ * MIT license, (c) Jasper Hugunin
+ * Link: https://github.com/jashug/IWTypes/blob/master/Adjointification.v
+ *)
 
 (* Turn a pair of inverses into an adjoint equivalence *)
 (* Proof follows the HoTT book *)

--- a/plugin/theories/Ornaments.v
+++ b/plugin/theories/Ornaments.v
@@ -1,3 +1,4 @@
+Require Ornamental.Adjoint.
 Require Ornamental.Unpack.
 Require Ornamental.Lifted.
 


### PR DESCRIPTION
This PR pulls in Jasper's HoTT module for adjointifying equivalences and applies its generic lemmas when equivalence-proving is enabled. The module is placed at `theories/Adjoint.v`.

For an ornament named `${ornament}`, this feature instantiates Jasper's `fg_id'` (to adjointify retraction) as `${ornament}_retraction` and `f_adjoint` (to prove adjunction) as `${ornament}_adjunction`.

The initial retraction proof (which is an input to the previous two lemmas) is now generated as `${ornament}_retraction0` to prevent a name collision. To actually benefit from the adjunction theorem, rewritings need to use the adjointified retraction lemma, hence the preferential naming scheme.

The test script (`test.sh`) passes successfully.

Some potential design concerns:
- Are you okay with adjunction sharing the same proof-generation option as section+retraction?
- Do you want the `Adjoint.v` module translated to use Ltac proof scripts instead of terms?
- Is the need to use adjointified retraction lemmas a problem? I wouldn't think so, but I wanted to mention it because the two versions' definitional equalities don't coincide (_e.g._, `refold_retraction` in `Example.v` does not hold, though a different proof could plausibly work).

If satisfactory, this feature would resolve issue #57.