### PR TITLE
Add support for swapping and renaming constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ certain equivalences between types in Coq. It began as the artifact for the ITP 
 Please cite this paper when referring to DEVOID. A version of DEVOID that corresponds to the
 ITP camera-ready can be found in [this release](http://github.com/uwplse/ornamental-search/releases/tag/itp+equiv).
 
-Basically, when you have two types A and B that are related in certain ways, DEVOID can search for
+Given two types A and B that are related in certain ways, DEVOID can search for
 and prove the relation between those types, then lift functions and proofs between them.
 The following relations are currently supported:
 
@@ -11,12 +11,12 @@ The following relations are currently supported:
 over A (like `length`)
 2. **Records and Tuples**: the type A is a nested tuple of the form `x * (y * ...)`, and the type B is
 a record with the same number of fields that have the same types
+3. **Swapping and Renaming Constructors**: the types A and B are two inductive types that are equal up to
+swapping constructor order and renaming constructors
 
 DEVOID is a part of the [PUMPKIN PATCH](https://github.com/uwplse/PUMPKIN-PATCH) 
 proof repair plugin suite, and is included as a dependency of PUMPKIN PATCH
 starting with release 0.1.
-
-TODO before merging, update w/ all of the swap stuff (find ornament, ambiguity, save ornament, lifting, examples)
 
 # Getting Started with DEVOID
 
@@ -78,7 +78,7 @@ For algebraic ornaments, `Find ornament` returns three functions if successful:
 
 `A_to_B` and `A_to_B_inv` form a specific equivalence, with `A_to_B_index` describing the fold over `A`.
 
-For records and products, `Find ornament` returns only the first two of these.
+For other kinds of ornaments, `Find ornament` returns only the first two of these.
 
 ##### Options for Correctness
 
@@ -117,10 +117,29 @@ You can also use this to substitute in a different equivalence for an existing o
 are some restrictions here on what is possible. See [ListToVectCustom.v](/plugin/coq/examples/ListToVectCustom.v)
 for more information.
 
+You can also skip one of promote or forget, provide just one, and let DEVOID find the other, for example:
+
+```
+Save ornament A B { promote = f }.
+```
+
+This is especially useful when there are many possible equivalences and you'd like to use a particular one,
+but let DEVOID figure out the rest. See [Swap.v](/plugin/coq/Swap.v) for examples of this.
+
+##### Ambiguity 
+
+Sometimes, DEVOID finds multiple possible equivalences. With swapping constructors in particular, there can
+be an exponential number of possible equivalences.
+
+In the case of ambiguity, DEVOID presents up to the first 50 possible
+options for the user (in a smart order), presents this as an error, and gives instructions for the user to
+provide more information to `Find ornament` in the next iteration. If the equivalence you want is not in the
+first 50 candidates, please use `Save ornament`. See [Swap.v](/plugin/coq/Swap.v) for examples of both of these.
+
 #### Lift
 
-See [Example.v](/plugin/coq/examples/Example.v) and [minimal_records.v](/plugin/coq/minimal_records.v) for
-examples of lifting.
+See [Example.v](/plugin/coq/examples/Example.v), [minimal_records.v](/plugin/coq/minimal_records.v),
+and [Swap.v](/plugin/coq/Swap.v) for examples of lifting.
 
 ##### Command
 
@@ -283,6 +302,10 @@ Here is an overview of the examples, in order of relevance to the paper:
 
 The most useful examples of lifting between tuples and records are in [minimal_records.v](/plugin/coq/minimal_records.v)
 and [more_records.v](/plugin/coq/more_records.v).
+
+## Swapping and Renaming Constructors Examples
+
+The most useful examples of swapping and renaming constructors are in [Swap.v](/plugin/coq/Swap.v).
 
 ## Other Examples
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ DEVOID is a part of the [PUMPKIN PATCH](https://github.com/uwplse/PUMPKIN-PATCH)
 proof repair plugin suite, and is included as a dependency of PUMPKIN PATCH
 starting with release 0.1.
 
+TODO before merging, update w/ all of the swap stuff (find ornament, ambiguity, save ornament, lifting, examples)
+
 # Getting Started with DEVOID
 
 This section of the README is a getting started guide for users.

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -25,6 +25,21 @@ Find ornament list list' as swap_list.
 Print swap_list.
 Print swap_list_inv.
 
+(* TODO automatically generate *)
+Lemma swap_list_section : forall T l, swap_list_inv T (swap_list T l) = l.
+Proof.
+  intros T l. induction l.
+  - reflexivity.
+  - simpl. rewrite IHl. reflexivity.
+Defined.
+
+Lemma swap_list_retraction : forall T l, swap_list T (swap_list_inv T l) = l.
+Proof.
+  intros T l. induction l.
+  - simpl. rewrite IHl. reflexivity.
+  - reflexivity.
+Defined.
+
 (* --- An ambiguous swap --- *)
 
 (*

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -10,7 +10,7 @@ Require Import List.
 Import ListNotations.
 
 Require Import Ornamental.Ornaments.
-(* Set DEVOID search prove equivalence. TODO once this is implemented *)
+Set DEVOID search prove equivalence.
 
 (* TODO run w/ tests once done *)
 
@@ -24,21 +24,8 @@ Find ornament list list' as swap_list.
 
 Print swap_list.
 Print swap_list_inv.
-
-(* TODO automatically generate *)
-Lemma swap_list_section : forall T l, swap_list_inv T (swap_list T l) = l.
-Proof.
-  intros T l. induction l.
-  - reflexivity.
-  - simpl. rewrite IHl. reflexivity.
-Defined.
-
-Lemma swap_list_retraction : forall T l, swap_list T (swap_list_inv T l) = l.
-Proof.
-  intros T l. induction l.
-  - simpl. rewrite IHl. reflexivity.
-  - reflexivity.
-Defined.
+Print swap_list_section.
+Print swap_list_retraction.
 
 (* --- An ambiguous swap --- *)
 

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -22,10 +22,10 @@ Inductive list' (T : Type) : Type :=
 
 Find ornament list list' as swap_list.
 
-Print swap_list.
-Print swap_list_inv.
-Print swap_list_section.
-Print swap_list_retraction.
+Check swap_list.
+Check swap_list_inv.
+Check swap_list_section.
+Check swap_list_retraction.
 
 (* --- An ambiguous swap --- *)
 
@@ -63,7 +63,8 @@ Inductive Term' : Set :=
  * proof mode and ask the user when this happens.
  *)
 
-Fail Find ornament Term Term'. (* WIP *)
+Fail Find ornament Term Term'. (* for now, we tell the user to pick one via an error *)
+Find ornament Term Term' { mapping 0 }. (* we pick one this way *)
 
 (* --- A more ambiguous swap --- *)
 

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -17,7 +17,10 @@ Inductive list' (T : Type) : Type :=
 | cons' : T -> list' T -> list' T
 | nil' : list' T.
 
-Fail Find ornament list list'. (* WIP *)
+Find ornament list list' as swap_list.
+
+Print swap_list.
+Print swap_list_inv.
 
 (* --- An ambiguous swap --- *)
 
@@ -92,3 +95,5 @@ Inductive Term''' : Set :=
 
 Fail Find ornament Term'' Term'''. (* WIP *)
 
+
+(* TODO try w/ dependent indices too *)

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -13,6 +13,8 @@ Require Import Ornamental.Ornaments.
 Set DEVOID search prove equivalence.
 
 (* TODO run w/ tests once done *)
+(* TODO lift *)
+(* TODO try w/ dependent indices too *)
 
 (* --- Swap the only constructor --- *)
 
@@ -21,11 +23,6 @@ Inductive list' (T : Type) : Type :=
 | nil' : list' T.
 
 Find ornament list list' as swap_list.
-
-Check swap_list.
-Check swap_list_inv.
-Check swap_list_section.
-Check swap_list_retraction.
 
 (* --- An ambiguous swap --- *)
 
@@ -82,7 +79,22 @@ Inductive Term'' : Set :=
   | Times'' : Term'' -> Term'' -> Term''
   | Choose'' : Identifier -> Term'' -> Term''.
 
-Fail Find ornament Term' Term''. (* WIP *)
+Fail Find ornament Term' Term''.
+Find ornament Term' Term'' { mapping 3 }.
+
+(* --- Note that we can do several at once --- *)
+
+Inductive Term''' : Set :=
+  | Var''' : Identifier -> Term'''
+  | Eq''' : Term''' -> Term''' -> Term'''
+  | Int''' : Z -> Term'''
+  | Minus''' : Term''' -> Term''' -> Term'''
+  | Plus''' : Term''' -> Term''' -> Term'''
+  | Times''' : Term''' -> Term''' -> Term'''
+  | Choose''' : Identifier -> Term''' -> Term'''.
+
+Fail Find ornament Term Term'''.
+Find ornament Term Term''' { mapping 3 }.
 
 (* --- Renaming --- *)
 
@@ -90,16 +102,14 @@ Fail Find ornament Term' Term''. (* WIP *)
  * Note from the above that renaming constructors is just the identity swap.
  *)
 
-Inductive Term''' : Set :=
-  | Var''' : Identifier -> Term'''
-  | Eq''' : Term''' -> Term''' -> Term'''
-  | Num''' : Z -> Term'''
-  | Minus''' : Term''' -> Term''' -> Term'''
-  | Plus''' : Term''' -> Term''' -> Term'''
-  | Times''' : Term''' -> Term''' -> Term'''
-  | Choose''' : Identifier -> Term''' -> Term'''.
+Inductive Term'''' : Set :=
+  | Var'''' : Identifier -> Term''''
+  | Eq'''' : Term'''' -> Term'''' -> Term''''
+  | Num'''' : Z -> Term''''
+  | Minus'''' : Term'''' -> Term'''' -> Term''''
+  | Plus'''' : Term'''' -> Term'''' -> Term''''
+  | Times'''' : Term'''' -> Term'''' -> Term''''
+  | Choose'''' : Identifier -> Term'''' -> Term''''.
 
-Fail Find ornament Term'' Term'''. (* WIP *)
-
-
-(* TODO try w/ dependent indices too *)
+Fail Find ornament Term''' Term''''.
+Find ornament Term''' Term'''' { mapping 0 }.

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -10,6 +10,7 @@ Require Import List.
 Import ListNotations.
 
 Require Import Ornamental.Ornaments.
+(* Set DEVOID search prove equivalence. TODO once this is implemented *)
 
 (* --- Swap the only constructor --- *)
 

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -12,6 +12,8 @@ Import ListNotations.
 Require Import Ornamental.Ornaments.
 (* Set DEVOID search prove equivalence. TODO once this is implemented *)
 
+(* TODO run w/ tests once done *)
+
 (* --- Swap the only constructor --- *)
 
 Inductive list' (T : Type) : Type :=

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -424,16 +424,6 @@ Proof.
   - apply e23.
   - apply e22.
   - apply e21.
-  - apply e20.
-  - apply e19.
-  - apply e18.
-  - apply e17.
-  - apply e16.
-  - apply e15.
-  - apply e14.
-  - apply e13.
-  - apply e12.
-  - apply e11.
   - apply e10.
   - apply e9.
   - apply e8.
@@ -444,6 +434,16 @@ Proof.
   - apply e3.
   - apply e2.
   - apply e1.
+  - apply e20.
+  - apply e19.
+  - apply e18.
+  - apply e17.
+  - apply e16.
+  - apply e15.
+  - apply e14.
+  - apply e13.
+  - apply e12.
+  - apply e11.
 Defined.
 
 Save ornament Enum Enum' { forget = Enum'_Enum }.
@@ -470,10 +470,10 @@ match e with
 end.
 
 Preprocess is_e2 as is_e2_pre.
-Lift Enum Enum' in is_e2_pre as is_e29'.
+Lift Enum Enum' in is_e2_pre as is_e19'.
 
-Lemma e29'_is_e29':
-  is_e29' e29'.
+Lemma e19'_is_e19':
+  is_e19' e19'.
 Proof.
   reflexivity.
 Defined.

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -14,6 +14,7 @@ Set DEVOID lift type.
 
 (* TODO test outcomes (if #changes, will break, whereas now won't change) *)
 (* TODO try w/ dependent indices too *)
+(* TODO clean & make tutorial-like *)
 
 (* --- Swap the only constructor --- *)
 
@@ -372,7 +373,44 @@ Proof.
   - apply e1'.
 Defined.
 
-(* Hopefully won't need this at some point *)
+(*
+ * DEVOID can automatically infer the opposite direction
+ *)
+Save ornament Enum Enum' { promote = Enum_Enum' }.
+
+Definition is_e3 (e : Enum) :=
+match e with
+| e3 => True
+| _ => False
+end.
+
+Preprocess is_e3 as is_e3_pre.
+Lift Enum Enum' in is_e3_pre as is_e28'.
+
+Lemma e28'_is_e28':
+  is_e28' e28'.
+Proof.
+  reflexivity.
+Defined.
+
+Definition is_e3' (e : Enum') :=
+match e with
+| e3' => True
+| _ => False
+end.
+
+Preprocess is_e3' as is_e3'_pre.
+Lift Enum' Enum in is_e3'_pre as is_e28.
+
+Lemma e28_is_e28:
+  is_e28 e28.
+Proof.
+  reflexivity.
+Defined.
+
+(*
+ * Likewise, we can just provide forget (could also do both):
+ *)
 Program Definition Enum'_Enum : Enum' -> Enum.
 Proof.
   intros e. induction e.
@@ -408,20 +446,36 @@ Proof.
   - apply e1.
 Defined.
 
-Save ornament Enum Enum' { promote = Enum_Enum'; forget = Enum'_Enum }.
+Save ornament Enum Enum' { forget = Enum'_Enum }.
 
-Definition is_e3 (e : Enum) :=
+Definition is_e2' (e : Enum') :=
 match e with
-| e3 => True
+| e2' => True
 | _ => False
 end.
 
-Preprocess is_e3 as is_e3_pre.
-Lift Enum Enum' in is_e3_pre as is_e28'.
+Preprocess is_e2' as is_e2'_pre.
+Lift Enum' Enum in is_e2'_pre as is_e29.
 
-Lemma e28'_is_e28':
-  is_e28' e28'.
+Lemma e29_is_e29:
+  is_e29 e29.
 Proof.
   reflexivity.
 Defined.
+
+Definition is_e2 (e : Enum) :=
+match e with
+| e2 => True
+| _ => False
+end.
+
+Preprocess is_e2 as is_e2_pre.
+Lift Enum Enum' in is_e2_pre as is_e29'.
+
+Lemma e29'_is_e29':
+  is_e29' e29'.
+Proof.
+  reflexivity.
+Defined.
+
 

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -351,16 +351,6 @@ Proof.
   - apply e23'.
   - apply e22'.
   - apply e21'.
-  - apply e20'.
-  - apply e19'.
-  - apply e18'.
-  - apply e17'.
-  - apply e16'.
-  - apply e15'.
-  - apply e14'.
-  - apply e13'.
-  - apply e12'.
-  - apply e11'.
   - apply e10'.
   - apply e9'.
   - apply e8'.
@@ -371,6 +361,16 @@ Proof.
   - apply e3'.
   - apply e2'.
   - apply e1'.
+  - apply e20'.
+  - apply e19'.
+  - apply e18'.
+  - apply e17'.
+  - apply e16'.
+  - apply e15'.
+  - apply e14'.
+  - apply e13'.
+  - apply e12'.
+  - apply e11'.
 Defined.
 
 (*
@@ -400,10 +400,10 @@ match e with
 end.
 
 Preprocess is_e3' as is_e3'_pre.
-Lift Enum' Enum in is_e3'_pre as is_e28.
+Lift Enum' Enum in is_e3'_pre as is_e18.
 
-Lemma e28_is_e28:
-  is_e28 e28.
+Lemma e18_is_e18:
+  is_e18 e18.
 Proof.
   reflexivity.
 Defined.

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -240,8 +240,6 @@ Find ornament Term''' Expr { mapping 0 }.
 
 Lift Module Term''' Expr in User5Session19''' as CustomRenaming.
 
-Print CustomRenaming.
-
 (* --- Large and ambiguous --- *)
 
 (*

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -79,10 +79,9 @@ Inductive Term'' : Set :=
   | Times'' : Term'' -> Term'' -> Term''
   | Choose'' : Identifier -> Term'' -> Term''.
 
-Fail Find ornament Term' Term''.
 Find ornament Term' Term'' { mapping 3 }.
 
-(* --- Note that we can do several at once --- *)
+(* --- Note that we can do several swaps at once --- *)
 
 Inductive Term''' : Set :=
   | Var''' : Identifier -> Term'''
@@ -93,7 +92,6 @@ Inductive Term''' : Set :=
   | Times''' : Term''' -> Term''' -> Term'''
   | Choose''' : Identifier -> Term''' -> Term'''.
 
-Fail Find ornament Term Term'''.
 Find ornament Term Term''' { mapping 3 }.
 
 (* --- Renaming --- *)
@@ -111,5 +109,82 @@ Inductive Term'''' : Set :=
   | Times'''' : Term'''' -> Term'''' -> Term''''
   | Choose'''' : Identifier -> Term'''' -> Term''''.
 
-Fail Find ornament Term''' Term''''.
 Find ornament Term''' Term'''' { mapping 0 }.
+
+(* --- Large and ambiguous --- *)
+
+(*
+ * TODO explain
+ * TODO then implement w/ "Save ornament" to try to prove section/retraction 
+ *)
+
+Inductive Enum : Set :=
+| e1 : Enum
+| e2 : Enum
+| e3 : Enum
+| e4 : Enum
+| e5 : Enum
+| e6 : Enum
+| e7 : Enum
+| e8 : Enum
+| e9 : Enum
+| e10 : Enum
+| e11 : Enum
+| e12 : Enum
+| e13 : Enum
+| e14 : Enum
+| e15 : Enum
+| e16 : Enum
+| e17 : Enum
+| e18 : Enum
+| e19 : Enum
+| e20 : Enum
+| e21 : Enum
+| e22 : Enum
+| e23 : Enum
+| e24 : Enum
+| e25 : Enum
+| e26 : Enum
+| e27 : Enum
+| e28 : Enum
+| e29 : Enum
+| e30 : Enum.
+
+Inductive Enum' : Set :=
+| e1' : Enum'
+| e2' : Enum'
+| e3' : Enum'
+| e4' : Enum'
+| e5' : Enum'
+| e6' : Enum'
+| e7' : Enum'
+| e8' : Enum'
+| e9' : Enum'
+| e10' : Enum'
+| e11' : Enum'
+| e12' : Enum'
+| e13' : Enum'
+| e14' : Enum'
+| e15' : Enum'
+| e16' : Enum'
+| e17' : Enum'
+| e18' : Enum'
+| e19' : Enum'
+| e20' : Enum'
+| e21' : Enum'
+| e22' : Enum'
+| e23' : Enum'
+| e24' : Enum'
+| e25' : Enum'
+| e26' : Enum'
+| e27' : Enum'
+| e28' : Enum'
+| e29' : Enum'
+| e30' : Enum'.
+
+Find ornament Enum Enum' { mapping 0 }.
+
+
+
+
+

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -202,7 +202,7 @@ Inductive Term'' : Set :=
   | Times'' : Term'' -> Term'' -> Term''
   | Choose'' : Identifier -> Term'' -> Term''.
 
-Find ornament Term' Term'' { mapping 3 }.
+Find ornament Term' Term'' { mapping 8 }.
 
 Lift Module Term' Term'' in User5Session19' as User5Session19''.
 
@@ -217,7 +217,7 @@ Inductive Term''' : Set :=
   | Times''' : Term''' -> Term''' -> Term'''
   | Choose''' : Identifier -> Term''' -> Term'''.
 
-Find ornament Term Term''' { mapping 3 }.
+Find ornament Term Term''' { mapping 8 }.
 
 Lift Module Term Term''' in User5Session19_pre as User5Session19'''.
 

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -12,7 +12,7 @@ Require Import Ornamental.Ornaments.
 Set DEVOID search prove equivalence.
 Set DEVOID lift type.
 
-(* TODO run w/ tests once done *)
+(* TODO test outcomes (if #changes, will break, whereas now won't change) *)
 (* TODO try w/ dependent indices too *)
 
 (* --- Swap the only constructor --- *)

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -10,11 +10,10 @@ Import ListNotations.
 
 Require Import Ornamental.Ornaments.
 Set DEVOID search prove equivalence.
+Set DEVOID lift type.
 
 (* TODO run w/ tests once done *)
-(* TODO lift *)
 (* TODO try w/ dependent indices too *)
-(* TODO test bwd *)
 
 (* --- Swap the only constructor --- *)
 
@@ -22,35 +21,31 @@ Inductive list' (T : Type) : Type :=
 | cons' : T -> list' T -> list' T
 | nil' : list' T.
 
-Find ornament list list' as swap_list.
+Preprocess Module List as List_pre { opaque (* ignore these: *)
+  (* dependent elimination only: *)
+  RelationClasses.StrictOrder_Transitive
+  RelationClasses.StrictOrder_Irreflexive
+  RelationClasses.Equivalence_Symmetric
+  RelationClasses.Equivalence_Transitive
+  RelationClasses.PER_Symmetric
+  RelationClasses.PER_Transitive
+  RelationClasses.Equivalence_Reflexive
+  (* proofs about these match over the above opaque terms, and would fail: *)
+  Nat.add
+  Nat.sub
+}.
+Lift Module list list' in List_pre as List'.
 
-Definition my_nil (T : Type) := @nil T.
-
-Lift list list' in my_nil as nil_lifted.
-
-Lemma test_nil:
-  nil_lifted = nil'.
+Lemma my_lemma:
+  forall (T : Type) (l : list' T),
+    List'.Coq_Init_Datatypes_app T l (nil' T) = List'.Coq_Init_Datatypes_app T (nil' T) l.
 Proof.
-  reflexivity.
-Qed.
+  intros T l. induction l.
+  - simpl. simpl in IHl. rewrite IHl. reflexivity.
+  - reflexivity.
+Defined.
 
-Definition my_cons (T : Type) (t : T) (l : list T) := @cons T t l.
-
-Lift list list' in my_cons as cons_lifted.
-
-Lemma test_cons:
-  cons_lifted = cons'.
-Proof.
-  reflexivity.
-Qed.
-
-Preprocess app as app_pre.
-Lift list list' in app_pre as app'.
-
-Print app_pre.
-Print app'.
-
-(* TODO lifting, both directions (need proper direction indicator impl) *)
+Lift list' list in my_lemma as my_lemma_lifted.
 
 (* --- An ambiguous swap --- *)
 

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -313,7 +313,115 @@ Inductive Enum' : Set :=
 
 Find ornament Enum Enum' { mapping 0 }.
 
+Definition is_e10 (e : Enum) :=
+match e with
+| e10 => True
+| _ => False
+end.
 
+Preprocess is_e10 as is_e10_pre.
+Lift Enum Enum' in is_e10_pre as is_e10'.
 
+Lemma e10'_is_e10':
+  is_e10' e10'.
+Proof.
+  reflexivity.
+Defined.
 
+(* --- Custom mapping --- *)
+
+(*
+ * If the mapping we want doesn't show up in the top 50 candidates, we can
+ * supply our own using "Save ornament". For now, we need to give both functions,
+ * and it doesn't prove anything for us; later, should be able to automatically
+ * invert the function and prove section/retraction (TODO).
+ *)
+
+Program Definition Enum_Enum' : Enum -> Enum'.
+Proof.
+  intros e. induction e.
+  - apply e30'.
+  - apply e29'.
+  - apply e28'.
+  - apply e27'.
+  - apply e26'.
+  - apply e25'.
+  - apply e24'.
+  - apply e23'.
+  - apply e22'.
+  - apply e21'.
+  - apply e20'.
+  - apply e19'.
+  - apply e18'.
+  - apply e17'.
+  - apply e16'.
+  - apply e15'.
+  - apply e14'.
+  - apply e13'.
+  - apply e12'.
+  - apply e11'.
+  - apply e10'.
+  - apply e9'.
+  - apply e8'.
+  - apply e7'.
+  - apply e6'.
+  - apply e5'.
+  - apply e4'.
+  - apply e3'.
+  - apply e2'.
+  - apply e1'.
+Defined.
+
+(* Hopefully won't need this at some point *)
+Program Definition Enum'_Enum : Enum' -> Enum.
+Proof.
+  intros e. induction e.
+  - apply e30.
+  - apply e29.
+  - apply e28.
+  - apply e27.
+  - apply e26.
+  - apply e25.
+  - apply e24.
+  - apply e23.
+  - apply e22.
+  - apply e21.
+  - apply e20.
+  - apply e19.
+  - apply e18.
+  - apply e17.
+  - apply e16.
+  - apply e15.
+  - apply e14.
+  - apply e13.
+  - apply e12.
+  - apply e11.
+  - apply e10.
+  - apply e9.
+  - apply e8.
+  - apply e7.
+  - apply e6.
+  - apply e5.
+  - apply e4.
+  - apply e3.
+  - apply e2.
+  - apply e1.
+Defined.
+
+Save ornament Enum Enum' { promote = Enum_Enum'; forget = Enum'_Enum }.
+
+Definition is_e3 (e : Enum) :=
+match e with
+| e3 => True
+| _ => False
+end.
+
+Preprocess is_e3 as is_e3_pre.
+Lift Enum Enum' in is_e3_pre as is_e28'.
+
+Lemma e28'_is_e28':
+  is_e28' e28'.
+Proof.
+  reflexivity.
+Defined.
 

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -14,6 +14,7 @@ Set DEVOID search prove equivalence.
 (* TODO run w/ tests once done *)
 (* TODO lift *)
 (* TODO try w/ dependent indices too *)
+(* TODO test bwd *)
 
 (* --- Swap the only constructor --- *)
 
@@ -26,8 +27,28 @@ Find ornament list list' as swap_list.
 Definition my_nil (T : Type) := @nil T.
 
 Lift list list' in my_nil as nil_lifted.
+
+Lemma test_nil:
+  nil_lifted = nil'.
+Proof.
+  reflexivity.
+Qed.
+
+Definition my_cons (T : Type) (t : T) (l : list T) := @cons T t l.
+
+Lift list list' in my_cons as cons_lifted.
+
+Lemma test_cons:
+  cons_lifted = cons'.
+Proof.
+  reflexivity.
+Qed.
+
 Preprocess app as app_pre.
 Lift list list' in app_pre as app'.
+
+Print app_pre.
+Print app'.
 
 (* TODO lifting, both directions (need proper direction indicator impl) *)
 

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -5,7 +5,6 @@
 Require Import List.
 Require Import String.
 Require Import ZArith.
-Require Import List.
 
 Import ListNotations.
 
@@ -23,6 +22,14 @@ Inductive list' (T : Type) : Type :=
 | nil' : list' T.
 
 Find ornament list list' as swap_list.
+
+Definition my_nil (T : Type) := @nil T.
+
+Lift list list' in my_nil as nil_lifted.
+Preprocess app as app_pre.
+Lift list list' in app_pre as app'.
+
+(* TODO lifting, both directions (need proper direction indicator impl) *)
 
 (* --- An ambiguous swap --- *)
 

--- a/plugin/coq/Swap.v
+++ b/plugin/coq/Swap.v
@@ -1,10 +1,12 @@
 (*
- * Tests for swapping/moving constructors
+ * DEVOID supports swapping and renaming constructors!
+ * Here are some examples.
  *)
 
 Require Import List.
 Require Import String.
 Require Import ZArith.
+Require Import Vector.
 
 Import ListNotations.
 
@@ -12,16 +14,17 @@ Require Import Ornamental.Ornaments.
 Set DEVOID search prove equivalence.
 Set DEVOID lift type.
 
-(* TODO test outcomes (if #changes, will break, whereas now won't change) *)
-(* TODO try w/ dependent indices too *)
-(* TODO clean & make tutorial-like *)
-
 (* --- Swap the only constructor --- *)
 
+(*
+ * Here we simply flip the constructors of list and then
+ * lift the entire list module:
+ *)
 Inductive list' (T : Type) : Type :=
 | cons' : T -> list' T -> list' T
 | nil' : list' T.
 
+(* Preprocess for lifting: *)
 Preprocess Module List as List_pre { opaque (* ignore these: *)
   (* dependent elimination only: *)
   RelationClasses.StrictOrder_Transitive
@@ -35,8 +38,11 @@ Preprocess Module List as List_pre { opaque (* ignore these: *)
   Nat.add
   Nat.sub
 }.
+
+(* Lift the whole list module: *)
 Lift Module list list' in List_pre as List'.
 
+(* A small test in the opposite direction that doesn't rely on caching: *)
 Lemma my_lemma:
   forall (T : Type) (l : list' T),
     List'.Coq_Init_Datatypes_app T l (nil' T) = List'.Coq_Init_Datatypes_app T (nil' T) l.
@@ -47,6 +53,39 @@ Proof.
 Defined.
 
 Lift list' list in my_lemma as my_lemma_lifted.
+
+(* --- Composing with algebraic ornaments --- *)
+
+(*
+ * We can compose this with an algebraic ornament:
+ *)
+Inductive vector' (T : Type) : nat -> Type :=
+| consV' : T -> forall (n : nat), vector' T n -> vector' T (S n)
+| nilV' : vector' T 0.
+
+Lift list' vector' in List'.Coq_Init_Datatypes_app as appV'.
+Lift list' vector' in my_lemma as my_lemmaV'.
+
+Lift vector' Vector.t in appV' as appV.
+Lift vector' Vector.t in my_lemmaV' as my_lemmaV.
+
+(*
+ * Note that these commute:
+ *)
+Lift list Vector.t in List_pre.Coq_Init_Datatypes_app as appV2.
+Lift list Vector.t in my_lemma_lifted as my_lemmaV2.
+
+Lemma test_app_commutes:
+  appV = appV2.
+Proof.
+  reflexivity.
+Qed.
+
+Lemma test_my_lemma_commutes:
+  my_lemmaV = my_lemmaV2.
+Proof.
+  reflexivity.
+Qed.
 
 (* --- An ambiguous swap --- *)
 
@@ -187,6 +226,16 @@ Find ornament Term Term' { mapping 0 }. (* we pick one this way *)
  *)
 Lift Module Term Term' in User5Session19_pre as User5Session19'.
 
+Lemma test_eval_eq_true_or_false:
+  forall (L : User5Session19'.EpsilonLogic)
+         env
+         (t1 t2 : Term'),
+       User5Session19'.eval L env (Eq' t1 t2) = User5Session19'.vTrue L \/
+       User5Session19'.eval L env (Eq' t1 t2) = User5Session19'.vFalse L.
+Proof.
+  exact User5Session19'.eval_eq_true_or_false.
+Qed.
+
 (* --- A more ambiguous swap --- *)
 
 (*
@@ -207,7 +256,22 @@ Find ornament Term' Term'' { mapping 8 }.
 
 Lift Module Term' Term'' in User5Session19' as User5Session19''.
 
+Lemma test_eval_eq_true_or_false_2:
+  forall (L : User5Session19''.EpsilonLogic)
+         env
+         (t1 t2 : Term''),
+       User5Session19''.eval L env (Eq'' t1 t2) = User5Session19''.vTrue L \/
+       User5Session19''.eval L env (Eq'' t1 t2) = User5Session19''.vFalse L.
+Proof.
+  exact User5Session19''.eval_eq_true_or_false.
+Qed.
+
 (* --- Note that we can do several swaps at once --- *)
+
+(*
+ * This just skips an intermediate step and lifts from Term' directly to Term'',
+ * though we redefine it as Term''' to break caching.
+ *)
 
 Inductive Term''' : Set :=
   | Var''' : Identifier -> Term'''
@@ -221,6 +285,16 @@ Inductive Term''' : Set :=
 Find ornament Term Term''' { mapping 8 }.
 
 Lift Module Term Term''' in User5Session19_pre as User5Session19'''.
+
+Lemma test_eval_eq_true_or_false_3:
+  forall (L : User5Session19'''.EpsilonLogic)
+         env
+         (t1 t2 : Term'''),
+       User5Session19'''.eval L env (Eq''' t1 t2) = User5Session19'''.vTrue L \/
+       User5Session19'''.eval L env (Eq''' t1 t2) = User5Session19'''.vFalse L.
+Proof.
+  exact User5Session19'''.eval_eq_true_or_false.
+Qed.
 
 (* --- Renaming --- *)
 
@@ -241,11 +315,21 @@ Find ornament Term''' Expr { mapping 0 }.
 
 Lift Module Term''' Expr in User5Session19''' as CustomRenaming.
 
+Lemma test_eval_equal_true_or_false:
+  forall (L : CustomRenaming.EpsilonLogic)
+         env
+         (e1 e2 : Expr),
+       CustomRenaming.eval L env (Equal e1 e2) = CustomRenaming.vTrue L \/
+       CustomRenaming.eval L env (Equal e1 e2) = CustomRenaming.vFalse L.
+Proof.
+  exact CustomRenaming.eval_eq_true_or_false.
+Qed.
+
 (* --- Large and ambiguous --- *)
 
 (*
- * TODO explain
- * TODO then implement w/ "Save ornament" to try to prove section/retraction 
+ * Here there are so many possible swaps that it makes no sense
+ * to show all of them. We show 50. The first one is renaming:
  *)
 
 Inductive Enum : Set :=
@@ -333,9 +417,9 @@ Defined.
 
 (*
  * If the mapping we want doesn't show up in the top 50 candidates, we can
- * supply our own using "Save ornament". For now, we need to give both functions,
- * and it doesn't prove anything for us; later, should be able to automatically
- * invert the function and prove section/retraction (TODO).
+ * supply our own using "Save ornament". We only need to provide "Save ornament"
+ * with one of two directions. It can find the other for us and prove
+ * the equivalence!
  *)
 
 Program Definition Enum_Enum' : Enum -> Enum'.
@@ -373,9 +457,6 @@ Proof.
   - apply e11'.
 Defined.
 
-(*
- * DEVOID can automatically infer the opposite direction
- *)
 Save ornament Enum Enum' { promote = Enum_Enum' }.
 
 Definition is_e3 (e : Enum) :=
@@ -409,73 +490,14 @@ Proof.
 Defined.
 
 (*
- * Likewise, we can just provide forget (could also do both):
+ * We could just as well have provided forget.
+ *
+ * Do note that if you change the equivalence when you run
+ * "Save ornament", this will not clear cached lifted terms,
+ * which may give you confusing results later if you lift using
+ * two different equivalences between the same types at different
+ * points in your code that depend on one another. If this is a
+ * problem for you, let us know and we can make it possible to
+ * clear the lifting cache.
  *)
-Program Definition Enum'_Enum : Enum' -> Enum.
-Proof.
-  intros e. induction e.
-  - apply e30.
-  - apply e29.
-  - apply e28.
-  - apply e27.
-  - apply e26.
-  - apply e25.
-  - apply e24.
-  - apply e23.
-  - apply e22.
-  - apply e21.
-  - apply e10.
-  - apply e9.
-  - apply e8.
-  - apply e7.
-  - apply e6.
-  - apply e5.
-  - apply e4.
-  - apply e3.
-  - apply e2.
-  - apply e1.
-  - apply e20.
-  - apply e19.
-  - apply e18.
-  - apply e17.
-  - apply e16.
-  - apply e15.
-  - apply e14.
-  - apply e13.
-  - apply e12.
-  - apply e11.
-Defined.
-
-Save ornament Enum Enum' { forget = Enum'_Enum }.
-
-Definition is_e2' (e : Enum') :=
-match e with
-| e2' => True
-| _ => False
-end.
-
-Preprocess is_e2' as is_e2'_pre.
-Lift Enum' Enum in is_e2'_pre as is_e29.
-
-Lemma e29_is_e29:
-  is_e29 e29.
-Proof.
-  reflexivity.
-Defined.
-
-Definition is_e2 (e : Enum) :=
-match e with
-| e2 => True
-| _ => False
-end.
-
-Preprocess is_e2 as is_e2_pre.
-Lift Enum Enum' in is_e2_pre as is_e19'.
-
-Lemma e19'_is_e19':
-  is_e19' e19'.
-Proof.
-  reflexivity.
-Defined.
-
 

--- a/plugin/coq/examples/ListToVectCustom.v
+++ b/plugin/coq/examples/ListToVectCustom.v
@@ -72,7 +72,7 @@ existT (fun H : nat => vector A H) (length l)
  * DEVOID to use our equivalence. (Use at your own risk! If you pick something that isn't an equivalence,
  * lifting will fail with confusing type errors.)
  *)
-Save ornament list vector { promote = ltv ; forget = list_to_t_inv }.
+Save ornament list vector { promote = ltv }.
 
 (*
  * The cute thing is that we can now lift all of these using the length function:

--- a/plugin/coq/examples/ListToVectCustom.v
+++ b/plugin/coq/examples/ListToVectCustom.v
@@ -7,6 +7,8 @@ Require Import List.
 
 Require Import Ornamental.Ornaments.
 
+Set DEVOID search prove equivalence.
+
 Notation vector := Vector.t.
 Notation vnil := Vector.nil.
 Notation vcons := Vector.cons.

--- a/plugin/src/automation/equivalence.ml
+++ b/plugin/src/automation/equivalence.ml
@@ -48,6 +48,13 @@ let equiv_motive env_motive sigma pms l =
        let trm1 = mkAppl (lift_back l, snoc (mkAppl (lift_to l, snoc trm2 pms)) pms) in
        let sigma, at_type = reduce_type env_motive sigma trm2 in
        sigma, apply_eq { at_type; trm1; trm2 }
+    | SwapConstruct _ ->
+       let trm1 = mkRel 1 in
+       let sigma, at_type = reduce_type env_motive sigma trm1 in
+       let typ_args = unfold_args at_type in
+       let trm1_lifted = mkAppl (lift_to l, snoc trm1 typ_args) in
+       let trm2 = mkAppl (lift_back l, snoc trm1_lifted typ_args) in
+       sigma, apply_eq { at_type; trm1; trm2 }
   in sigma, shift (reconstruct_lambda_n env_motive p_b (List.length pms))
 
 (* --- Algebraic ornaments  --- *)
@@ -357,6 +364,166 @@ let equiv_proof_curry_record env sigma l =
   let equiv_b = equiv_proof_body_curry_record env_to sigma p pms l in
   reconstruct_lambda env_to equiv_b
 
+(* --- Swap Constructor --- *)
+
+(* TODO clean before merging, refactor common code w/ aglebraic. this was done by copying and pasting the algebraic ornament proof procedure code, so there is a _lot_ of common code *)
+
+(*
+ * This looks very similar to algebraic, except that it swaps constructors
+ * in the appropriate places.
+ *)
+
+(*
+ * Form the environment with the appropriate hypotheses for the equality lemmas.
+ * Take as arguments the original environment, an evar_map, the recursive
+ * arguments for the particular case, and a lift config.
+ *)
+let eq_lemmas_env_swap_construct env recs l =
+  fold_left_state
+    (fun e r sigma ->
+      let r1 = shift_by (new_rels2 e env) r in
+      let sigma, r_t = reduce_type e sigma r1 in
+      (* push new rec arg *)
+      let e_r = push_local (Anonymous, r_t) e in
+      let sigma, r1 = sigma, shift_by (new_rels2 e_r e) r1 in
+      let sigma, r2 = sigma, mkRel 1 in
+      let sigma, r_t = reduce_type e_r sigma r1 in
+      let r_eq = apply_eq {at_type = r_t; trm1 = r1; trm2 = r2} in
+      (* push equality *)
+      sigma, push_local (Anonymous, r_eq) e_r)
+    env
+    recs
+
+(*
+ * Determine the equality lemmas for each case of an inductive type for an
+ * algebraic ornament.
+ *)
+let eq_lemmas_swap_construct env sigma typ l =
+  let ((i, i_index), u) = destInd typ in
+  map_state_array
+    (fun c_index sigma ->
+      let c = mkConstructU (((i, i_index), c_index + 1), u) in
+      let sigma, c_exp = expand_eta env sigma c in
+      let (env_c_b, c_body) = zoom_lambda_term env c_exp in
+      let c_body = reduce_stateless reduce_term env_c_b sigma c_body in
+      let c_args = unfold_args c_body in
+      let recs = List.filter (on_red_type_default (ignore_env (is_or_applies typ)) env_c_b sigma) c_args in
+      let sigma, env_lemma = eq_lemmas_env_swap_construct env_c_b recs l sigma in
+      let c_body = shift_by (new_rels2 env_lemma env_c_b) c_body in
+      let sigma, c_body_type = reduce_type env_lemma sigma c_body in
+      (* reflexivity proof: the identity case *)
+      let refl = apply_eq_refl { typ = c_body_type; trm = c_body } in
+      (* fold to recursively substitute each recursive argument *)
+      let (body, _, _) =
+        List.fold_right
+          (fun _ (b, h, c_app) ->
+            let h_r = destRel h in
+            let (_, _, h_t) = CRD.to_tuple @@ lookup_rel h_r env_lemma in
+            let app = dest_eq (shift_by h_r h_t) in
+            let at_type = app.at_type in
+            let r1 = app.trm1 in
+            let r2 = app.trm2 in
+            let c_body_b = shift c_body in
+            let c_app_b = shift c_app in
+            let abs_c_app = all_eq_substs (shift r1, mkRel 1) c_app_b in
+            let c_app_trans = all_eq_substs (r1, r2) c_app in
+            let typ_b = shift c_body_type in
+            let p_b = { at_type = typ_b; trm1 = c_body_b; trm2 = abs_c_app } in
+            let p = mkLambda (Anonymous, at_type, apply_eq p_b) in
+            let eq_proof_app = {at_type; p; trm1 = r1; trm2 = r2; h; b} in
+            let eq_proof = apply_eq_ind eq_proof_app in
+            (eq_proof, shift_by 2 h, c_app_trans))
+          recs
+          (refl, mkRel 1, c_body)
+      in sigma, reconstruct_lambda env_lemma body)
+    (Array.mapi
+       (fun i _ -> i)
+       ((lookup_mind i env).mind_packets.(i_index)).mind_consnames)
+    sigma
+
+(*
+ * Get a case of the proof of section/retraction
+ * Take as arguments an environment, an evar_map, the parameters,
+ * the motive of the section/retraction proof, the equality lemma for the case,
+ * the type of the eliminator corresponding to the case, and a lifting config.
+ *
+ * The inner function works by tracking a list of regular hypotheses
+ * and new arguments for the equality lemma, then applying them in the body.
+ *)
+let equiv_case_swap_construct env sigma pms p eq_lemma l c =
+  let eq_lemma = mkAppl (eq_lemma, pms) in (* curry eq_lemma with pms *)
+  let rec case e depth hypos args c =
+    match kind c with
+    | App (_, _) ->
+       (* conclusion: apply eq lemma and beta-reduce *)
+       let all_args = List.rev_append hypos (List.rev args) in
+       reduce_stateless reduce_term e sigma (mkAppl (shift_by depth eq_lemma, all_args))
+    | Prod (n, t, b) ->
+       let case_b = case (push_local (n, t) e) (shift_i depth) in
+       let p_rel = shift_by depth (mkRel 1) in
+       let h = mkRel 1 in
+       if applies p_rel t then
+         (* IH *)
+         let t = reduce_stateless reduce_term e sigma (mkAppl (shift_by depth p, unfold_args t)) in
+         let trm = (dest_eq t).trm2 in
+         let args = trm :: args in
+         mkLambda (n, t, case_b (shift_all hypos) (h :: shift_all args) b)
+       else
+         (* Product *)
+         mkLambda (n, t, case_b (h :: shift_all hypos) (shift_all args) b)
+    | _ ->
+       failwith "unexpected case"
+  in case env 0 [] [] c
+
+(*
+ * Get the cases of the proof of section/retraction
+ * Take as arguments the environment with the motive type pushed,
+ * an evar_map, the parameters, the motive, the equality lemmas,
+ * the lifting, and the type of the eliminator body after the motive
+ *)
+let equiv_cases_swap_construct env sigma pms p lemmas l elim_typ =
+  List.mapi
+    (fun j -> equiv_case_swap_construct env sigma pms p lemmas.(j) l)
+    (take (Array.length lemmas) (factor_product elim_typ))
+
+(*
+ * Prove section/retraction for an algebraic ornament
+ *)
+let equiv_proof_swap_construct env sigma l =
+  let to_body = lookup_definition env (lift_to l) in
+  let env_to = zoom_env zoom_lambda_term env to_body in
+  let sigma, typ_app = reduce_type env_to sigma (mkRel 1) in
+  let typ = first_fun (zoom_if_sig_app typ_app) in
+  let ((i, i_index), _) = destInd typ in
+  let npm = (lookup_mind i env).mind_nparams in
+  let nargs = new_rels env_to npm in
+  let sigma, lemmas = eq_lemmas_swap_construct env sigma typ l in (* equality lemmas *)
+  let env_eq_proof = env_to in
+  let elim = type_eliminator env_to (i, i_index) in
+  let sigma, elim_typ = infer_type env sigma elim in
+  let (env_pms, elim_typ_p) = zoom_n_prod env npm elim_typ in
+  let (n, p_t, elim_typ) = destProd elim_typ_p in
+  let env_p = push_local (n, p_t) env_pms in
+  let pms = shift_all (mk_n_rels npm) in
+  let env_motive = zoom_env zoom_product_type env_pms p_t in
+  let sigma, p = equiv_motive env_motive sigma pms l in
+  let cs = equiv_cases_swap_construct env_p sigma pms p lemmas l elim_typ in
+  let args = mk_n_rels nargs in
+  let depth = new_rels2 env_eq_proof env_p in
+  let eq_proof =
+    apply_eliminator
+      {
+        elim;
+        pms = shift_all_by depth pms;
+        p = shift_by depth p;
+        cs = shift_all_by depth cs;
+        final_args = args;
+      }
+  in
+  let eq_typ = on_red_type_default (ignore_env dest_eq) env_eq_proof sigma eq_proof in
+  let equiv_b = apply_eq_sym { eq_typ; eq_proof } in
+  reconstruct_lambda env_to equiv_b
+                     
 (* --- Top-level equivalence proof generation --- *)
                      
 (*
@@ -368,6 +535,8 @@ let equiv_proof env sigma l =
      equiv_proof_algebraic env sigma l off
   | CurryRecord ->
      equiv_proof_curry_record env sigma l
+  | SwapConstruct _ ->
+     equiv_proof_swap_construct env sigma l
                         
 (*
  * Prove section and retraction

--- a/plugin/src/automation/equivalence.ml
+++ b/plugin/src/automation/equivalence.ml
@@ -273,7 +273,6 @@ let equiv_proof_algebraic env sigma l off =
         let at_type = shift typ_app in
         let p_b = apply_eq { at_type; trm1 = mkRel 1; trm2 } in
         let p = reconstruct_lambda_n env_p p_b (nb_rel env_to) in
-        (* ^ TODO use equiv_motive *)
         let to_elim = dest_sigT typ_app in
         elim_sigT { to_elim; packed_type = p; unpacked; arg = mkRel 1 })
       l
@@ -335,7 +334,7 @@ let equiv_proof_body_curry_record env_to sigma p pms l =
       let proof_body =
         if equal prod (first_fun typ2) then
           let to_elim = dest_prod typ2 in
-          let p = (* TODO can we use equiv_motive? *)
+          let p =
             let pms = shift_all pms in
             let arg_abs = all_eq_substs (shift curr, curr) (shift arg) in
             let trm2 = mkAppl (lift_back l, snoc (mkAppl (lift_to l, snoc arg_abs pms)) pms) in

--- a/plugin/src/automation/equivalence.ml
+++ b/plugin/src/automation/equivalence.ml
@@ -65,67 +65,29 @@ let equiv_motive env_motive pms l is_packed sigma =
  * The first step to constructing these is to construct the environment
  * with the appropriate hypotheses for these lemmas:
  *)
-let eq_lemmas_env env recs l =
-  match l.orn.kind with
-  | Algebraic (_, off) ->
-     (* TODO consolidate *)
-     fold_left_state
-       (fun e r sigma ->
-         let r1 = shift_by (new_rels2 e env) r in
-         let sigma, r_t = reduce_type e sigma r1 in
-         let push_ib =
-           map_backward
-             (fun (sigma, e) ->
-               Util.on_snd
-                 (fun t -> push_local (Anonymous, t) e)
-                 (reduce_type e sigma (get_arg off r_t)))
-             l
-         in
-         (* push index in backwards direction *)
-         let sigma, e_ib = push_ib (sigma, e) in
-         let adj_back = map_backward (reindex_app (reindex off (mkRel 1))) l in
-         let r_t = adj_back (shift_by (new_rels2 e_ib e) r_t) in
-         (* push new rec arg *)
-         let e_r = push_local (Anonymous, r_t) e_ib in
-         let pack_back = map_backward (fun (sigma, t) -> pack e_r l t sigma) l in
-         let sigma, r1 = pack_back (sigma, shift_by (new_rels2 e_r e) r1) in
-         let sigma, r2 = pack_back (sigma, mkRel 1) in
-         let sigma, r_t = reduce_type e_r sigma r1 in
-         let r_eq = apply_eq {at_type = r_t; trm1 = r1; trm2 = r2} in
-         (* push equality *)
-         sigma, push_local (Anonymous, r_eq) e_r)
-       env
-       recs
-  | SwapConstruct _ ->
-     fold_left_state
-       (fun e r sigma ->
-         let r1 = shift_by (new_rels2 e env) r in
-         let sigma, r_t = reduce_type e sigma r1 in
-         (* push new rec arg *)
-         let e_r = push_local (Anonymous, r_t) e in
-         let sigma, r1 = sigma, shift_by (new_rels2 e_r e) r1 in
-         let sigma, r2 = sigma, mkRel 1 in
-         let sigma, r_t = reduce_type e_r sigma r1 in
-         let r_eq = apply_eq {at_type = r_t; trm1 = r1; trm2 = r2} in
-         (* push equality *)
-         sigma, push_local (Anonymous, r_eq) e_r)
-       env
-       recs
-  | _ ->
-     raise NotAlgebraic (* TODO better error message here  *)
-               
-(* --- Algebraic ornaments  --- *)
+let eq_lemmas_env env recs l pack_typ pack_trm =
+  fold_left_state
+    (fun e r sigma ->
+      let r1 = shift_by (new_rels2 e env) r in
+      let sigma, r_t = reduce_type e sigma r1 in
+      (* if applicable, pack the type *)
+      let sigma, (e_ib, r_t) = pack_typ e r_t sigma in
+      (* push new rec arg *)
+      let e_r = push_local (Anonymous, r_t) e_ib in
+      (* get the (possibly packed) equality type *)
+      let sigma, r1 = pack_trm e_r (shift_by (new_rels2 e_r e) r1) sigma in
+      let sigma, r2 = pack_trm e_r (mkRel 1) sigma in
+      let sigma, r_t = reduce_type e_r sigma r1 in
+      let r_eq = apply_eq {at_type = r_t; trm1 = r1; trm2 = r2} in
+      (* push the equality *)
+      sigma, push_local (Anonymous, r_eq) e_r)
+    env
+    recs
 
 (*
- * To construct these proofs, we first construct the lemmas, then
- * specialize them to the appropriate arguments.
+ * Then, we prove the equality lemmas:
  *)
-
-(*
- * Determine the equality lemmas for each case of an inductive type for an
- * algebraic ornament.
- *)
-let eq_lemmas_algebraic env sigma typ l off =
+let eq_lemmas env typ l pack_typ pack_trm nindices abstract_c_app sub_c_app_trans sigma =
   let ((i, i_index), u) = destInd typ in
   map_state_array
     (fun c_index sigma ->
@@ -135,16 +97,15 @@ let eq_lemmas_algebraic env sigma typ l off =
       let c_body = reduce_stateless reduce_term env_c_b sigma c_body in
       let c_args = unfold_args c_body in
       let recs = List.filter (on_red_type_default (ignore_env (is_or_applies typ)) env_c_b sigma) c_args in
-      let sigma, env_lemma = eq_lemmas_env env_c_b recs l sigma in
-      let pack_back = map_backward (fun (sigma, t) -> pack env_lemma l t sigma) l in
-      let sigma, c_body = pack_back (sigma, shift_by (new_rels2 env_lemma env_c_b) c_body) in
+      let sigma, env_lemma = eq_lemmas_env env_c_b recs l pack_typ pack_trm sigma in
+      let sigma, c_body = pack_trm env_lemma (shift_by (new_rels2 env_lemma env_c_b) c_body) sigma in
       let sigma, c_body_type = reduce_type env_lemma sigma c_body in
       (* reflexivity proof: the identity case *)
       let refl = apply_eq_refl { typ = c_body_type; trm = c_body } in
-      (* fold to recursively substitute each recursive argument *)
       let (body, _, _) =
         List.fold_right
           (fun _ (b, h, c_app) ->
+            (* fold to recursively substitute each recursive argument *)
             let h_r = destRel h in
             let (_, _, h_t) = CRD.to_tuple @@ lookup_rel h_r env_lemma in
             let app = dest_eq (shift_by h_r h_t) in
@@ -153,31 +114,14 @@ let eq_lemmas_algebraic env sigma typ l off =
             let r2 = app.trm2 in
             let c_body_b = shift c_body in
             let c_app_b = shift c_app in
-            let (abs_c_app, c_app_trans) =
-              if l.is_fwd then
-                let abs_c_app = all_eq_substs (shift r1, mkRel 1) c_app_b in
-                let c_app_trans = all_eq_substs (r1, r2) c_app in
-                (abs_c_app, c_app_trans)
-              else
-                let (r1_ex, r2_ex) = map_tuple dest_existT (r1, r2) in
-                let r1_u = r1_ex.unpacked in
-                let r2_u = r2_ex.unpacked in
-                let r1_ib = r1_ex.index in
-                let r2_ib = r2_ex.index in
-                let b_sig_typ = dest_sigT (shift at_type) in
-                let (ib, u) = projections b_sig_typ (mkRel 1) in
-                let abs_c_app_u = all_eq_substs (shift r1_u, u) c_app_b in
-                let abs_c_app = all_eq_substs (shift r1_ib, ib) abs_c_app_u in
-                let c_app_trans_u = all_eq_substs (r1_u, r2_u) c_app in
-                let c_app_trans = all_eq_substs (r1_ib, r2_ib) c_app_trans_u in
-                (abs_c_app, c_app_trans)
-            in
+            let abs_c_app = abstract_c_app (r1, r2) at_type c_app_b in
+            let c_app_trans = sub_c_app_trans (r1, r2) c_app in
             let typ_b = shift c_body_type in
             let p_b = { at_type = typ_b; trm1 = c_body_b; trm2 = abs_c_app } in
             let p = mkLambda (Anonymous, at_type, apply_eq p_b) in
             let eq_proof_app = {at_type; p; trm1 = r1; trm2 = r2; h; b} in
             let eq_proof = apply_eq_ind eq_proof_app in
-            (eq_proof, shift_by (directional l 2 3) h, c_app_trans))
+            (eq_proof, shift_by (2 + nindices) h, c_app_trans))
           recs
           (refl, mkRel 1, c_body)
       in sigma, reconstruct_lambda env_lemma body)
@@ -195,7 +139,7 @@ let eq_lemmas_algebraic env sigma typ l off =
  * The inner function works by tracking a list of regular hypotheses
  * and new arguments for the equality lemma, then applying them in the body.
  *)
-let equiv_case_algebraic env sigma pms p eq_lemma l c =
+let equiv_case env pms p eq_lemma l c dest_term sigma =
   let eq_lemma = mkAppl (eq_lemma, pms) in (* curry eq_lemma with pms *)
   let rec case e depth hypos args c =
     match kind c with
@@ -211,15 +155,8 @@ let equiv_case_algebraic env sigma pms p eq_lemma l c =
          (* IH *)
          let t = reduce_stateless reduce_term e sigma (mkAppl (shift_by depth p, unfold_args t)) in
          let trm = (dest_eq t).trm2 in
-         let args =
-           map_directional
-             (fun xs -> trm :: xs)
-             (fun xs ->
-               let (ib, u) = projections (on_red_type_default (ignore_env dest_sigT) e sigma trm) trm in
-               u :: ib :: xs)
-             l
-             args
-         in mkLambda (n, t, case_b (shift_all hypos) (h :: shift_all args) b)
+         let args = List.rev_append (dest_term e trm sigma) args in
+         mkLambda (n, t, case_b (shift_all hypos) (h :: shift_all args) b)
        else
          (* Product *)
          mkLambda (n, t, case_b (h :: shift_all hypos) (shift_all args) b)
@@ -233,15 +170,16 @@ let equiv_case_algebraic env sigma pms p eq_lemma l c =
  * an evar_map, the parameters, the motive, the equality lemmas,
  * the lifting, and the type of the eliminator body after the motive
  *)
-let equiv_cases_algebraic env sigma pms p lemmas l elim_typ =
+let equiv_cases equiv_case env pms p lemmas l elim_typ sigma =
   List.mapi
-    (fun j -> equiv_case_algebraic env sigma pms p lemmas.(j) l)
+    (fun j c -> equiv_case env pms p lemmas.(j) l c sigma)
     (take (Array.length lemmas) (factor_product elim_typ))
 
 (*
- * Prove section/retraction for an algebraic ornament
+ * Prove section/retraction for either algebraic ornaments or
+ * swapping/renaming constructors
  *)
-let equiv_proof_algebraic env sigma l off =
+let equiv_proof eq_lemmas equiv_case is_packed unpack_env index_args unpack_eq_proof env l sigma =
   let to_body = lookup_definition env (lift_to l) in
   let env_to = zoom_env zoom_lambda_term env to_body in
   let sigma, typ_app = reduce_type env_to sigma (mkRel 1) in
@@ -249,18 +187,8 @@ let equiv_proof_algebraic env sigma l off =
   let ((i, i_index), _) = destInd typ in
   let npm = (lookup_mind i env).mind_nparams in
   let nargs = new_rels env_to npm in
-  let sigma, lemmas = eq_lemmas_algebraic env sigma typ l off in (* equality lemmas *)
-  let env_eq_proof = (* unpack env_to for retraction *)
-    map_backward
-      (fun env ->
-        let b_sig_typ = dest_sigT typ_app in
-        let ib_typ = b_sig_typ.index_type in
-        let env_ib = push_local (Anonymous, ib_typ) env_to in
-        let b_typ = mkAppl (shift b_sig_typ.packer, [mkRel 1]) in
-        push_local (Anonymous, b_typ) env_ib)
-      l
-      env_to
-  in
+  let sigma, lemmas = eq_lemmas env typ l sigma in (* equality lemmas *)
+  let env_eq_proof = unpack_env env_to typ_app in
   let elim = type_eliminator env_to (i, i_index) in
   let sigma, elim_typ = infer_type env sigma elim in
   let (env_pms, elim_typ_p) = zoom_n_prod env npm elim_typ in
@@ -268,11 +196,10 @@ let equiv_proof_algebraic env sigma l off =
   let env_p = push_local (n, p_t) env_pms in
   let pms = shift_all (mk_n_rels npm) in
   let env_motive = zoom_env zoom_product_type env_pms p_t in
-  let sigma, p = equiv_motive env_motive pms l (not l.is_fwd) sigma in
-  let cs = equiv_cases_algebraic env_p sigma pms p lemmas l elim_typ in
+  let sigma, p = equiv_motive env_motive pms l is_packed sigma in
+  let cs = equiv_cases equiv_case env_p pms p lemmas l elim_typ sigma in
   let args = shift_all_by (new_rels2 env_eq_proof env_to) (mk_n_rels nargs) in
-  let index_back = map_backward (insert_index (off - npm) (mkRel 2)) l in
-  let reindex_back = map_backward (reindex nargs (mkRel 1)) l in
+  let final_args = index_args npm args in
   let depth = new_rels2 env_eq_proof env_p in
   let eq_proof =
     apply_eliminator
@@ -281,27 +208,181 @@ let equiv_proof_algebraic env sigma l off =
         pms = shift_all_by depth pms;
         p = shift_by depth p;
         cs = shift_all_by depth cs;
-        final_args = reindex_back (index_back args);
+        final_args;
       }
   in
   let eq_typ = on_red_type_default (ignore_env dest_eq) env_eq_proof sigma eq_proof in
-  let eq_proof =
-    map_backward
-      (fun unpacked -> (* eliminate sigT for retraction *)
-        let env_p = push_local (Anonymous, typ_app) env_to in
-        let trm2 = unshift (all_eq_substs (eq_typ.trm1, mkRel 2) eq_typ.trm2) in
-        let at_type = shift typ_app in
-        let p_b = apply_eq { at_type; trm1 = mkRel 1; trm2 } in
-        let p = reconstruct_lambda_n env_p p_b (nb_rel env_to) in
-        let to_elim = dest_sigT typ_app in
-        elim_sigT { to_elim; packed_type = p; unpacked; arg = mkRel 1 })
-      l
-      (reconstruct_lambda_n env_eq_proof eq_proof (nb_rel env_to))
-  in
-  let eq_typ = on_red_type_default (ignore_env dest_eq) env_to sigma eq_proof in
-  let equiv_b = apply_eq_sym { eq_typ; eq_proof } in
+  let packed = reconstruct_lambda_n env_eq_proof eq_proof (nb_rel env_to) in
+  let eq_proof_unpacked = unpack_eq_proof env_to typ_app eq_typ packed in
+  let eq_typ = on_red_type_default (ignore_env dest_eq) env_to sigma eq_proof_unpacked in
+  let equiv_b = apply_eq_sym { eq_typ; eq_proof = eq_proof_unpacked } in
   reconstruct_lambda env_to equiv_b
 
+(* --- Algebraic ornaments  --- *)
+
+(*
+ * To construct these proofs, we first construct the lemmas, then
+ * specialize them to the appropriate arguments.
+ *
+ * We construct the lemmas by calling the generic method, with some
+ * special HOFs for packing indices in the backward case.
+ *)
+let eq_lemmas_algebraic env typ l =
+  match l.orn.kind with
+  | Algebraic (_, off) ->
+     if l.is_fwd then
+       eq_lemmas
+         env
+         typ
+         l
+         (fun env typ -> ret (env, typ)) (* no packing types *)
+         (fun _ trm -> ret trm) (* no packing terms *)
+         0 (* no indices *)
+         (fun (r1, r2) _ -> all_eq_substs (shift r1, mkRel 1)) (* no packing *)
+         all_eq_substs (* basic substitution *)
+     else
+       eq_lemmas
+         env
+         typ
+         l
+         (fun env typ sigma ->
+           (* push index for packing in backward direction *)
+           let sigma, env_ib =
+             Util.on_snd
+               (fun t -> push_local (Anonymous, t) env)
+               (reduce_type env sigma (get_arg off typ))
+           in sigma, (env_ib, reindex_app (reindex off (mkRel 1)) (shift typ)))
+         (fun env -> pack env l) (* pack terms *)
+         1 (* one index *)
+         (fun (r1, r2) at_type c_app_b ->
+           (* abstract both indices and values *)
+           let (r1_ex, r2_ex) = map_tuple dest_existT (r1, r2) in
+           let r1_u = r1_ex.unpacked in
+           let r1_ib = r1_ex.index in
+           let b_sig_typ = dest_sigT (shift at_type) in
+           let (ib, u) = projections b_sig_typ (mkRel 1) in
+           let abs_c_app_u = all_eq_substs (shift r1_u, u) c_app_b in
+           all_eq_substs (shift r1_ib, ib) abs_c_app_u)
+         (fun (r1, r2) c_app ->
+           (* substitute both indices and values *)
+           let (r1_ex, r2_ex) = map_tuple dest_existT (r1, r2) in
+           let r1_u = r1_ex.unpacked in
+           let r2_u = r2_ex.unpacked in
+           let r1_ib = r1_ex.index in
+           let r2_ib = r2_ex.index in
+           let c_app_trans_u = all_eq_substs (r1_u, r2_u) c_app in
+           all_eq_substs (r1_ib, r2_ib) c_app_trans_u)
+  | _ ->
+     raise NotAlgebraic
+        
+(*
+ * Get a case of the proof of section/retraction
+ * Take as arguments an environment, an evar_map, the parameters,
+ * the motive of the section/retraction proof, the equality lemma for the case,
+ * the type of the eliminator corresponding to the case, and a lifting config.
+ *
+ * The inner function works by tracking a list of regular hypotheses
+ * and new arguments for the equality lemma, then applying them in the body.
+ *)
+let equiv_case_algebraic env pms p eq_lemma l c =
+  equiv_case
+    env
+    pms
+    p
+    eq_lemma
+    l
+    c
+    (fun env trm sigma ->
+      if l.is_fwd then
+        (* nothing to project *)
+        [trm]
+      else
+        (* project index and value *)
+        let (ib, u) = projections (on_red_type_default (ignore_env dest_sigT) env sigma trm) trm in
+        [ib; u])
+
+(*
+ * Prove section/retraction for an algebraic ornament
+ *)
+let equiv_proof_algebraic env l =
+  match l.orn.kind with
+  | Algebraic (_, off) ->
+     if l.is_fwd then
+       equiv_proof
+         eq_lemmas_algebraic
+         equiv_case_algebraic
+         false
+         (fun env _ -> env)
+         (fun _ args -> args)
+         (fun _ _ _ eq_proof -> eq_proof)
+         env
+         l
+     else
+       equiv_proof
+         eq_lemmas_algebraic
+         equiv_case_algebraic
+         true (* new index for retraction *)
+         (fun env typ_app ->
+           (* unpack env for retraction *)
+           let b_sig_typ = dest_sigT typ_app in
+           let ib_typ = b_sig_typ.index_type in
+           let env_ib = push_local (Anonymous, ib_typ) env in
+           let b_typ = mkAppl (shift b_sig_typ.packer, [mkRel 1]) in
+           push_local (Anonymous, b_typ) env_ib)
+         (fun npm args ->
+           (* reindex the args for retraction *)
+           let index_back = insert_index (off - npm) (mkRel 2) in
+           let reindex_back = reindex (List.length args) (mkRel 1) in
+           reindex_back (index_back args))
+         (fun env typ_app eq_typ eq_proof ->
+           let env_p = push_local (Anonymous, typ_app) env in
+           let trm2 = unshift (all_eq_substs (eq_typ.trm1, mkRel 2) eq_typ.trm2) in
+           let at_type = shift typ_app in
+           let p_b = apply_eq { at_type; trm1 = mkRel 1; trm2 } in
+           let p = reconstruct_lambda_n env_p p_b (nb_rel env) in
+           let to_elim = dest_sigT typ_app in
+           elim_sigT { to_elim; packed_type = p; unpacked = eq_proof; arg = mkRel 1 })
+         env
+         l
+  | _ ->
+     raise NotAlgebraic
+
+(* --- Swap Constructor --- *)
+
+(*
+ * This looks very similar to algebraic, except that it swaps constructors
+ * in the appropriate places, and has no packing/unpacking since the number
+ * of indices does not change. First we get the equality lemmas:
+ *)
+let eq_lemmas_swap env typ l =
+  eq_lemmas
+    env
+    typ
+    l
+    (fun env typ -> ret (env, typ)) (* no packing types *)
+    (fun _ trm -> ret trm) (* no packing terms *)
+    0 (* no indices *)
+    (fun (r1, r2) _ -> all_eq_substs (shift r1, mkRel 1)) (* no packing *)
+    all_eq_substs (* basic substitution *)
+
+(*
+ * Get a case of section/retraction
+ *)
+let equiv_case_swap env pms p eq_lemma l c =
+  equiv_case env pms p eq_lemma l c (fun _ trm _ -> [trm])
+
+(*
+ * Prove section/retraction for swapping constructors
+ *)
+let equiv_proof_swap =
+  equiv_proof
+    eq_lemmas_swap
+    equiv_case_swap
+    false
+    (fun env _ -> env)
+    (fun _ args -> args)
+    (fun _ _ _ eq_proof -> eq_proof)
+                     
 (* --- Curry record --- *)
 
 (*
@@ -310,6 +391,9 @@ let equiv_proof_algebraic env sigma l off =
  * In the forward case, this eliminates over the inductive type.
  * In the backward case, this recursively eliminates over product types,
  * until there are no more nested pairs to eliminate.
+ *
+ * This looks different from algebraic ornaments and swapping constructors,
+ * mostly due to the need to recursively eliminate over products.
  *)
 let equiv_proof_body_curry_record env_to sigma p pms l =
   let arg = mkRel 1 in
@@ -375,7 +459,7 @@ let equiv_proof_body_curry_record env_to sigma p pms l =
 (*
  * Prove section/retraction for curry record
  *)
-let equiv_proof_curry_record env sigma l =
+let equiv_proof_curry_record env l sigma =
   let to_body = lookup_definition env (lift_to l) in
   let env_to = zoom_env zoom_lambda_term env to_body in
   let npm = nb_rel env_to - 1 in
@@ -385,165 +469,26 @@ let equiv_proof_curry_record env sigma l =
   let eq_typ = on_red_type_default (ignore_env dest_eq) env_to sigma eq_proof in
   let equiv_b = apply_eq_sym { eq_typ; eq_proof } in
   reconstruct_lambda env_to equiv_b
-
-(* --- Swap Constructor --- *)
-
-(* TODO clean before merging, refactor common code w/ aglebraic. this was done by copying and pasting the algebraic ornament proof procedure code, so there is a _lot_ of common code *)
-
-(*
- * This looks very similar to algebraic, except that it swaps constructors
- * in the appropriate places.
- *)
-
-(*
- * Determine the equality lemmas for each case of an inductive type for an
- * algebraic ornament.
- *)
-let eq_lemmas_swap_construct env sigma typ l =
-  let ((i, i_index), u) = destInd typ in
-  map_state_array
-    (fun c_index sigma ->
-      let c = mkConstructU (((i, i_index), c_index + 1), u) in
-      let sigma, c_exp = expand_eta env sigma c in
-      let (env_c_b, c_body) = zoom_lambda_term env c_exp in
-      let c_body = reduce_stateless reduce_term env_c_b sigma c_body in
-      let c_args = unfold_args c_body in
-      let recs = List.filter (on_red_type_default (ignore_env (is_or_applies typ)) env_c_b sigma) c_args in
-      let sigma, env_lemma = eq_lemmas_env env_c_b recs l sigma in
-      let c_body = shift_by (new_rels2 env_lemma env_c_b) c_body in
-      let sigma, c_body_type = reduce_type env_lemma sigma c_body in
-      (* reflexivity proof: the identity case *)
-      let refl = apply_eq_refl { typ = c_body_type; trm = c_body } in
-      (* fold to recursively substitute each recursive argument *)
-      let (body, _, _) =
-        List.fold_right
-          (fun _ (b, h, c_app) ->
-            let h_r = destRel h in
-            let (_, _, h_t) = CRD.to_tuple @@ lookup_rel h_r env_lemma in
-            let app = dest_eq (shift_by h_r h_t) in
-            let at_type = app.at_type in
-            let r1 = app.trm1 in
-            let r2 = app.trm2 in
-            let c_body_b = shift c_body in
-            let c_app_b = shift c_app in
-            let abs_c_app = all_eq_substs (shift r1, mkRel 1) c_app_b in
-            let c_app_trans = all_eq_substs (r1, r2) c_app in
-            let typ_b = shift c_body_type in
-            let p_b = { at_type = typ_b; trm1 = c_body_b; trm2 = abs_c_app } in
-            let p = mkLambda (Anonymous, at_type, apply_eq p_b) in
-            let eq_proof_app = {at_type; p; trm1 = r1; trm2 = r2; h; b} in
-            let eq_proof = apply_eq_ind eq_proof_app in
-            (eq_proof, shift_by 2 h, c_app_trans))
-          recs
-          (refl, mkRel 1, c_body)
-      in sigma, reconstruct_lambda env_lemma body)
-    (Array.mapi
-       (fun i _ -> i)
-       ((lookup_mind i env).mind_packets.(i_index)).mind_consnames)
-    sigma
-
-(*
- * Get a case of the proof of section/retraction
- * Take as arguments an environment, an evar_map, the parameters,
- * the motive of the section/retraction proof, the equality lemma for the case,
- * the type of the eliminator corresponding to the case, and a lifting config.
- *
- * The inner function works by tracking a list of regular hypotheses
- * and new arguments for the equality lemma, then applying them in the body.
- *)
-let equiv_case_swap_construct env sigma pms p eq_lemma l c =
-  let eq_lemma = mkAppl (eq_lemma, pms) in (* curry eq_lemma with pms *)
-  let rec case e depth hypos args c =
-    match kind c with
-    | App (_, _) ->
-       (* conclusion: apply eq lemma and beta-reduce *)
-       let all_args = List.rev_append hypos (List.rev args) in
-       reduce_stateless reduce_term e sigma (mkAppl (shift_by depth eq_lemma, all_args))
-    | Prod (n, t, b) ->
-       let case_b = case (push_local (n, t) e) (shift_i depth) in
-       let p_rel = shift_by depth (mkRel 1) in
-       let h = mkRel 1 in
-       if applies p_rel t then
-         (* IH *)
-         let t = reduce_stateless reduce_term e sigma (mkAppl (shift_by depth p, unfold_args t)) in
-         let trm = (dest_eq t).trm2 in
-         let args = trm :: args in
-         mkLambda (n, t, case_b (shift_all hypos) (h :: shift_all args) b)
-       else
-         (* Product *)
-         mkLambda (n, t, case_b (h :: shift_all hypos) (shift_all args) b)
-    | _ ->
-       failwith "unexpected case"
-  in case env 0 [] [] c
-
-(*
- * Get the cases of the proof of section/retraction
- * Take as arguments the environment with the motive type pushed,
- * an evar_map, the parameters, the motive, the equality lemmas,
- * the lifting, and the type of the eliminator body after the motive
- *)
-let equiv_cases_swap_construct env sigma pms p lemmas l elim_typ =
-  List.mapi
-    (fun j -> equiv_case_swap_construct env sigma pms p lemmas.(j) l)
-    (take (Array.length lemmas) (factor_product elim_typ))
-
-(*
- * Prove section/retraction for an algebraic ornament
- *)
-let equiv_proof_swap_construct env sigma l =
-  let to_body = lookup_definition env (lift_to l) in
-  let env_to = zoom_env zoom_lambda_term env to_body in
-  let sigma, typ_app = reduce_type env_to sigma (mkRel 1) in
-  let typ = first_fun (zoom_if_sig_app typ_app) in
-  let ((i, i_index), _) = destInd typ in
-  let npm = (lookup_mind i env).mind_nparams in
-  let nargs = new_rels env_to npm in
-  let sigma, lemmas = eq_lemmas_swap_construct env sigma typ l in (* equality lemmas *)
-  let env_eq_proof = env_to in
-  let elim = type_eliminator env_to (i, i_index) in
-  let sigma, elim_typ = infer_type env sigma elim in
-  let (env_pms, elim_typ_p) = zoom_n_prod env npm elim_typ in
-  let (n, p_t, elim_typ) = destProd elim_typ_p in
-  let env_p = push_local (n, p_t) env_pms in
-  let pms = shift_all (mk_n_rels npm) in
-  let env_motive = zoom_env zoom_product_type env_pms p_t in
-  let sigma, p = equiv_motive env_motive pms l false sigma in
-  let cs = equiv_cases_swap_construct env_p sigma pms p lemmas l elim_typ in
-  let args = mk_n_rels nargs in
-  let depth = new_rels2 env_eq_proof env_p in
-  let eq_proof =
-    apply_eliminator
-      {
-        elim;
-        pms = shift_all_by depth pms;
-        p = shift_by depth p;
-        cs = shift_all_by depth cs;
-        final_args = args;
-      }
-  in
-  let eq_typ = on_red_type_default (ignore_env dest_eq) env_eq_proof sigma eq_proof in
-  let equiv_b = apply_eq_sym { eq_typ; eq_proof } in
-  reconstruct_lambda env_to equiv_b
                      
 (* --- Top-level equivalence proof generation --- *)
                      
 (*
  * Prove section/retraction
  *)
-let equiv_proof env sigma l =
+let prove_section_or_retraction env sigma l =
   match l.orn.kind with
   | Algebraic (indexer, off) ->
-     equiv_proof_algebraic env sigma l off
+     equiv_proof_algebraic env l sigma
   | CurryRecord ->
-     equiv_proof_curry_record env sigma l
+     equiv_proof_curry_record env l sigma
   | SwapConstruct _ ->
-     equiv_proof_swap_construct env sigma l
+     equiv_proof_swap env l sigma
                         
 (*
  * Prove section and retraction
  *)
 let prove_equivalence env sigma =
-  twice_directional (equiv_proof env sigma)
+  twice_directional (prove_section_or_retraction env sigma)
 
 (* --- Automatically generated adjunction proof --- *)
 

--- a/plugin/src/automation/lift/lift.ml
+++ b/plugin/src/automation/lift/lift.ml
@@ -301,10 +301,9 @@ let lift_case env c npms c_elim constr sigma =
     sigma, reconstruct_lambda_n env_c body (nb_rel env)
 
 (* Lift cases *)
-(* TODO somehow need to swap when we have SwapConstr here *)
 let lift_cases env c npms p_elim cs =
   let cs =
-    match (get_lifting c).orn.kind with
+    match (get_lifting (reverse c)).orn.kind with
     | SwapConstruct swaps ->
        (* swap the order before eliminating *)
        let cs_arr = Array.of_list cs in

--- a/plugin/src/automation/lift/liftconfig.ml
+++ b/plugin/src/automation/lift/liftconfig.ml
@@ -373,7 +373,6 @@ let pack_to_typ c env unpacked sigma =
              
 (*
  * NORMALIZE (the result of this is cached)
- * TODO refactor common etc
  *)
 let lift_constr env sigma c trm =
   let l = c.l in

--- a/plugin/src/automation/lift/liftconfig.ml
+++ b/plugin/src/automation/lift/liftconfig.ml
@@ -292,7 +292,22 @@ let initialize_elim_types c env sigma =
   let bwd_elim_typ = directional l b_t a_t in
   let elim_types = (fwd_elim_typ, bwd_elim_typ) in
   sigma, { c with elim_types }
-              
+
+(*
+ * Utility function: Map over the constructors of a type 
+ *)
+let map_constrs f env typ sigma =
+  let ((i, i_index), u) = destInd typ in
+  let mutind_body = lookup_mind i env in
+  let ind_bodies = mutind_body.mind_packets in
+  let ind_body = ind_bodies.(i_index) in
+  map_state_array
+    (f env)
+    (Array.mapi
+       (fun c_index _ -> mkConstructU (((i, i_index), c_index + 1), u))
+       ind_body.mind_consnames)
+    sigma
+  
 (*
  * Initialize the packed constructors for each type
  *)
@@ -300,15 +315,10 @@ let initialize_packed_constrs c env sigma =
   let a_typ, b_typ = c.typs in
   let l = c.l in
   let sigma, a_constrs =
-    let ((i, i_index), u) = destInd a_typ in
-    let mutind_body = lookup_mind i env in
-    let ind_bodies = mutind_body.mind_packets in
-    let ind_body = ind_bodies.(i_index) in
-    map_state_array
-      (fun constr sigma -> expand_eta env sigma constr)
-      (Array.mapi
-         (fun c_index _ -> mkConstructU (((i, i_index), c_index + 1), u))
-         ind_body.mind_consnames)
+    map_constrs
+      (fun env constr sigma -> expand_eta env sigma constr)
+      env
+      a_typ
       sigma
   in
   let sigma, b_constrs =
@@ -316,32 +326,21 @@ let initialize_packed_constrs c env sigma =
     | Algebraic _ ->
        let b_typ_packed = dummy_index env sigma (dest_sigT (zoom_term zoom_lambda_term env b_typ)).packer in
        let b_typ_inner = first_fun b_typ_packed in
-       let ((i, i_index), u) = destInd b_typ_inner in
-       let mutind_body = lookup_mind i env in
-       let ind_bodies = mutind_body.mind_packets in
-       let ind_body = ind_bodies.(i_index) in
-       map_state_array
-         (fun constr sigma ->
+       map_constrs
+         (fun env constr sigma ->
            let sigma, constr_exp = expand_eta env sigma constr in
            let (env_c_b, c_body) = zoom_lambda_term env constr_exp in
            let c_body = reduce_stateless reduce_term env_c_b sigma c_body in
            let sigma, packed = pack env_c_b l c_body sigma in
            sigma, reconstruct_lambda_n env_c_b packed (nb_rel env))
-           (Array.mapi
-              (fun c_index _ ->
-                mkConstructU (((i, i_index), c_index + 1), u))
-              ind_body.mind_consnames)
-           sigma
-    | SwapConstruct swaps ->
-       let ((i, i_index), u) = destInd b_typ in
-       let mutind_body = lookup_mind i env in
-       let ind_bodies = mutind_body.mind_packets in
-       let ind_body = ind_bodies.(i_index) in
-       map_state_array
-         (fun constr sigma -> expand_eta env sigma constr)
-         (Array.mapi
-            (fun c_index _ -> mkConstructU (((i, i_index), c_index + 1), u))
-            ind_body.mind_consnames)
+         env
+         b_typ_inner
+         sigma
+    | SwapConstruct _ ->
+       map_constrs
+         (fun env constr sigma -> expand_eta env sigma constr)
+         env
+         b_typ
          sigma
     | CurryRecord ->
        let a_constr = a_constrs.(0) in

--- a/plugin/src/automation/lift/liftconfig.ml
+++ b/plugin/src/automation/lift/liftconfig.ml
@@ -112,16 +112,21 @@ let get_elim_type c = fst (c.elim_types)
  * unification.
  *)
 let optimize_is_from c env typ =
-  let (a_typ, _) = c.typs in
+  let (a_typ, b_typ) = c.typs in
   if c.l.is_fwd then
-    (* We don't need unification here *)
     if is_or_applies a_typ typ then
       Some (unfold_args typ)
     else
       None
   else
-    (* Defer to unification *)
-    None
+    match c.l.orn.kind with
+    | SwapConstruct _ ->
+       if is_or_applies b_typ typ then
+         Some (unfold_args typ)
+       else
+         None
+    | _ ->
+       None
     
 (*
  * Determine whether a type is the type we are ornamenting from
@@ -263,6 +268,9 @@ let initialize_types l env sigma =
   | CurryRecord ->
      let sigma, b_t = expand_eta env sigma (first_fun b_i_t) in
      sigma, (a_t, b_t)
+  | SwapConstruct _ ->
+     let b_t = first_fun b_i_t in
+     sigma, (a_t, b_t)
 
 (*
  * Initialize the type of the eliminator
@@ -275,6 +283,8 @@ let initialize_elim_types c env sigma =
     | Algebraic _ ->
        let b_typ_packed = dummy_index env sigma (dest_sigT (zoom_term zoom_lambda_term env b_t)).packer in
        first_fun b_typ_packed
+    | SwapConstruct _ ->
+       b_t
     | _ ->
        prod
   in
@@ -322,6 +332,17 @@ let initialize_packed_constrs c env sigma =
                 mkConstructU (((i, i_index), c_index + 1), u))
               ind_body.mind_consnames)
            sigma
+    | SwapConstruct swaps ->
+       let ((i, i_index), u) = destInd b_typ in
+       let mutind_body = lookup_mind i env in
+       let ind_bodies = mutind_body.mind_packets in
+       let ind_body = ind_bodies.(i_index) in
+       map_state_array
+         (fun constr sigma -> expand_eta env sigma constr)
+         (Array.mapi
+            (fun c_index _ -> mkConstructU (((i, i_index), c_index + 1), u))
+            ind_body.mind_consnames)
+         sigma
     | CurryRecord ->
        let a_constr = a_constrs.(0) in
        let (env_c_b, c_body) = zoom_lambda_term env a_constr in
@@ -353,6 +374,7 @@ let pack_to_typ c env unpacked sigma =
              
 (*
  * NORMALIZE (the result of this is cached)
+ * TODO refactor common etc
  *)
 let lift_constr env sigma c trm =
   let l = c.l in
@@ -364,6 +386,15 @@ let lift_constr env sigma c trm =
      let args = unfold_args (map_backward last_arg l trm) in
      let sigma, packed_args = map_backward pack_args l (sigma, args) in
      let sigma, rec_args = filter_state (fun tr sigma -> let sigma, o = type_is_from c env tr sigma in sigma, Option.has_some o) packed_args sigma in
+     if List.length rec_args = 0 then
+       (* base case - don't bother refolding *)
+       reduce_nf env sigma app
+     else
+       (* inductive case - refold *)
+       refold l env (lift_to l) app rec_args sigma
+  | SwapConstruct _ ->
+     let args = unfold_args trm in
+     let sigma, rec_args = filter_state (fun tr sigma -> let sigma, o = type_is_from c env tr sigma in sigma, Option.has_some o) args sigma in
      if List.length rec_args = 0 then
        (* base case - don't bother refolding *)
        reduce_nf env sigma app
@@ -424,6 +455,9 @@ let initialize_proj_rules env sigma c =
        let projT1 = reconstruct_lambda env_proj (project_index b_sig_typ (mkRel 1)) in
        let projT2 = reconstruct_lambda env_proj (project_value b_sig_typ (mkRel 1)) in
        sigma, [(projT1, p1); (projT2, p2)]
+  | SwapConstruct _ ->
+     (* no projections *)
+     sigma, []
   | CurryRecord ->
      (* accessors <-> projections *)
      let accessors =
@@ -475,6 +509,8 @@ let initialize_optimize_proj_packed_rules c =
      let proj1_rule = (fun a -> (dest_existT a).index) in
      let proj2_rule = (fun a -> (dest_existT a).unpacked) in
      is_or_applies existT, [(projT1, proj1_rule); (projT2, proj2_rule)]
+  | SwapConstruct _ ->
+     (fun _ -> false), []
   | CurryRecord ->
      let proj1_rule = (fun a -> (dest_pair a).Produtils.trm1) in
      let proj2_rule = (fun a -> (dest_pair a).Produtils.trm2) in

--- a/plugin/src/automation/lift/liftrules.ml
+++ b/plugin/src/automation/lift/liftrules.ml
@@ -173,6 +173,8 @@ let is_packed_constr c env sigma trm =
     match l.orn.kind with
     | Algebraic _ ->
        is_packed_inductive_constr (is_packed c) last_arg trm
+    | SwapConstruct _ ->
+       is_packed_inductive_constr (fun _ -> true) id trm
     | CurryRecord ->
        if is_packed c trm then
           let sigma_right, args_opt = type_is_from c env trm sigma in
@@ -205,6 +207,9 @@ let is_pack c env sigma trm =
          Util.on_snd Option.has_some (right_type trm)
        else
          sigma, false
+    | SwapConstruct _ ->
+       (* no packing *)
+       sigma, false
     | CurryRecord ->
        (* taken care of by constructor rule *)
        sigma, false
@@ -320,7 +325,11 @@ let determine_lift_rule c env trm sigma =
           if not l.is_fwd then
             sigma, LiftConstr (lifted_constr, args)
           else
-            sigma, Optimization (SmartLiftConstr (lifted_constr, args))
+            match l.orn.kind with
+            | SwapConstruct _ ->
+               sigma, LiftConstr (lifted_constr, args)
+            | _ ->
+               sigma, Optimization (SmartLiftConstr (lifted_constr, args))
         else
           sigma, LiftConstr (lifted_constr, args)
       else

--- a/plugin/src/automation/search.ml
+++ b/plugin/src/automation/search.ml
@@ -692,7 +692,9 @@ let find_promote_forget_swap env npm swaps a b sigma =
   sigma, { promote ; forget ; kind = SwapConstruct swaps_ints }
 
 (*
- * TODO clean etc
+ * TODO clean etc (before merging, have a better heuristic for enumerating
+ * in order starting with one swap, then two, etc. and limiting the number.
+ * probably simple recursion rather than folds.)
  *)
 let rec get_likely_swap_maps swaps : ((pconstructor * pconstructor) list) list =
   match swaps with
@@ -801,7 +803,6 @@ let search_swap_constructor env npm grouped a b swap_i_o sigma =
     if List.length ambiguous > 0 then
       (* Ambiguous; need more information *)
       let swap_maps = take 50 (get_likely_swap_maps swaps) in
-      Printf.printf "swap_maps: %d\n" (List.length swap_maps);
       if Option.has_some swap_i_o then
         let swap_i = Option.get swap_i_o in
         List.nth swap_maps swap_i

--- a/plugin/src/automation/search.ml
+++ b/plugin/src/automation/search.ml
@@ -672,7 +672,7 @@ let prompt_swap_ambiguous env swap_maps ambiguous sigma =
  * Find the motive for promote or forget for swapping constructors
  *)
 let find_motive_swap env_motive typ nargs pms =
-  let typ_args = List.append (shift_all_by nargs pms) (mk_n_rels (nargs - 1)) in
+  let typ_args = List.append (shift_all_by nargs pms) (shift_all (mk_n_rels (nargs - 1))) in
   let p_b = mkAppl (typ, typ_args) in
   reconstruct_lambda_n env_motive p_b (List.length pms)
 
@@ -684,7 +684,7 @@ let find_cases_swap env p elim_p_typ swap_map o nargs sigma =
   let ncons = List.length swap_map in
   List.mapi
     (fun i c ->
-      let env_c_b, c_b = zoom_product_type env_p c in
+      let env_c_b, c_b = zoom_product_type env_p (shift_by (nargs - 1) c) in
       let (ind, u) = destInd o in
       let constr_from = ((ind, (i + 1)), u) in
       let constr_to = List.assoc constr_from swap_map in
@@ -718,7 +718,7 @@ let find_cases_swap env p elim_p_typ swap_map o nargs sigma =
       in
       let constr_ih = mkAppl (mkConstructU constr_to, args_sub) in
       let c_p = reconstruct_lambda_n env_c_b constr_ih (nb_rel env_p) in
-      all_eq_substs (mkRel 1, shift_by nargs p) c_p)
+      all_eq_substs (mkRel nargs, shift_by nargs p) c_p)
     (take ncons (factor_product elim_p_typ))
         
 (*
@@ -758,6 +758,9 @@ let find_promote_forget_swap env npm swaps promote_o forget_o a b sigma =
       forget_o
       sigma
   in
+  let open Printing in
+  debug_term env promote "promote";
+  debug_term env forget "forget";
   let swaps_ints = List.map (fun (((_, i), _), ((_, j), _)) -> i, j) swaps in
   sigma, { promote ; forget ; kind = SwapConstruct swaps_ints }
            

--- a/plugin/src/automation/search.ml
+++ b/plugin/src/automation/search.ml
@@ -1027,13 +1027,17 @@ let search_common env sigma indexer_id_opt swap_i_o typ_o typ_n promote_o forget
        
 (*
  * Search for an ornament between two types.
+ *
+ * Eventually, we should move the optional arguments to some configuration.
  *)
 let search_orn env sigma indexer_id_opt swap_i_o typ_o typ_n =
   search_common env sigma indexer_id_opt swap_i_o typ_o typ_n None None
 
 (*
  * Try to invert a single component of an ornament between two types.
- * TODO move partially to inversion
+ *
+ * Eventually, we should move the optoinal arguments to some configuration,
+ * and we should move this to the inversion component at least partially.
  *)
 let invert_orn env sigma indexer_id_opt swap_i_o typ_o typ_n promote_o forget_o =
   if Option.has_some promote_o && Option.has_some forget_o then

--- a/plugin/src/automation/search.ml
+++ b/plugin/src/automation/search.ml
@@ -758,9 +758,6 @@ let find_promote_forget_swap env npm swaps promote_o forget_o a b sigma =
       forget_o
       sigma
   in
-  let open Printing in
-  debug_term env promote "promote";
-  debug_term env forget "forget";
   let swaps_ints = List.map (fun (((_, i), _), ((_, j), _)) -> i, j) swaps in
   sigma, { promote ; forget ; kind = SwapConstruct swaps_ints }
            

--- a/plugin/src/automation/search.ml
+++ b/plugin/src/automation/search.ml
@@ -829,7 +829,7 @@ let search_swap_constructor env npm grouped swap_i_o promote_o forget_o a b sigm
     if Option.has_some trm_o_o then
       (* Infer swap map from promotion function *)
       let f = Option.get trm_o_o in
-      let ((i_o, ii_o), u_o) = destInd a in
+      let ((i_o, ii_o), u_o) = destInd (if Option.has_some promote_o then a else b) in
       let m_o = lookup_mind i_o env in
       let b_o = m_o.mind_packets.(0) in
       let cs_o = b_o.mind_consnames in

--- a/plugin/src/automation/search.ml
+++ b/plugin/src/automation/search.ml
@@ -687,8 +687,9 @@ let find_promote_or_forget_swap env npm swap_map a b is_fwd sigma =
 
 let find_promote_forget_swap env npm swaps a b sigma =
   let sigma, promote = find_promote_or_forget_swap env npm swaps a b true sigma in
-  let sigma, forget = find_promote_or_forget_swap env npm swaps a b false sigma in (* TODO return the actual swapped constructors, and allow for more than one swap here *)
-  sigma, { promote ; forget ; kind = SwapConstruct (0, 0) }
+  let sigma, forget = find_promote_or_forget_swap env npm swaps a b false sigma in
+  let swaps_ints = List.map (fun (((_, i), _), ((_, j), _)) -> i, j) swaps in
+  sigma, { promote ; forget ; kind = SwapConstruct swaps_ints }
   
 (*
  * Search for the components of the equivalence for swapping constructors

--- a/plugin/src/automation/search.ml
+++ b/plugin/src/automation/search.ml
@@ -704,8 +704,8 @@ let search_swap_constructor env npm grouped a b sigma =
       grouped
   in
   if List.exists (fun (_, ((ms_a, _), _)) -> List.length ms_a > 1) swaps then
-    (* Ambiguous; need more information *)
-    failwith "ambiguous swaps are a WIP"
+    (* Ambiguous; need more information *) (* TODO implement *)
+    CErrors.user_err (Pp.str "ambiguous swaps aren't yet implemented")
   else
     (* Unambiguous *)
     let swap_map =

--- a/plugin/src/automation/search.ml
+++ b/plugin/src/automation/search.ml
@@ -758,7 +758,7 @@ let prompt_swap_ambiguous env swap_maps sigma =
         Pp.fnl ();
         Pp.str "Please choose the mapping you'd like to use. ";
         Pp.str "Then, pass that to DEVOID by calling `Find ornament` again. ";
-        Pp.str "For example: `Find ornament old new { mapping 0 }."])
+        Pp.str "For example: `Find ornament old new { mapping 0 }.`"])
 
 (*
  * Search for the components of the equivalence for swapping constructors

--- a/plugin/src/automation/search.ml
+++ b/plugin/src/automation/search.ml
@@ -32,6 +32,26 @@ open Stateutils
 open Desugarprod
 open Ornerrors
 open Convertibility
+open Promotion
+
+(* --- Common code --- *)
+       
+(*
+ * Find promote and forget, using a directional flag for abstraction
+ *)
+let find_promote_forget find_promote_or_forget promote_o forget_o sigma =
+  let sigma, promote =
+    if Option.has_some promote_o then
+      sigma, Option.get promote_o
+    else
+      find_promote_or_forget true sigma
+  in
+  let sigma, forget =
+    if Option.has_some forget_o then
+      sigma, Option.get forget_o
+    else
+      find_promote_or_forget false sigma
+  in sigma, (promote, forget)
 
 (* --- Finding the new index --- *)
 
@@ -460,8 +480,9 @@ let pack_orn f_indexer is_fwd =
   if is_fwd then pack_conclusion f_indexer else pack_hypothesis
 
 (* Search for the promotion or forgetful function *)
-let find_promote_or_forget_algebraic env_pms idx indexer_n o n is_fwd =
+let find_promote_or_forget_algebraic env_pms idx indexer_n a b is_fwd sigma =
   let directional x y = if is_fwd then x else y in
+  let (o, n) = directional (a, b) (b, a) in
   let (o_typ, arity_o, elim, elim_o_typ) = o in
   let (n_typ, arity_n, _, elim_n_typ) = n in
   let npm = nb_rel env_pms in
@@ -479,44 +500,35 @@ let find_promote_or_forget_algebraic env_pms idx indexer_n o n is_fwd =
   let n = (n_typ, directional elim_n_typ elim_a_typ_exp) in
   let p = promote_forget_motive off env_p_o typ arity npm f_indexer_opt in
   let adj = directional identity shift in
-  bind
-    (promote_forget_cases_algebraic env_pms off is_fwd (adj (shift p)) nargs o n)
-    (fun cs ->
-      let unpacked =
-        apply_eliminator
-          {
-            elim;
-            pms = shift_all_by nargs (mk_n_rels npm);
-            p = shift_by nargs p;
-            cs = List.map adj cs;
-            final_args = mk_n_rels nargs;
-          }
-      in
-      let o = (o_typ, arity_o) in
-      let n = (n_typ, arity_n) in
-      let idx = (npm + off, idx_t) in
-      let b = directional n o in
-      bind
-        (pack_orn f_indexer is_fwd env_p_o idx b unpacked)
-        (fun (env_packed, packed) ->
-          ret (reconstruct_lambda env_packed packed)))
-
-(* Find promote and forget, using a directional flag for abstraction
- * TODO test, clean/consolidate new code
- *)
-let find_promote_forget_algebraic env_pms idx indexer_n promote_o forget_o a b sigma =
-  let sigma, promote =
-    if Option.has_some promote_o then
-      sigma, Option.get promote_o
-    else
-      find_promote_or_forget_algebraic env_pms idx indexer_n a b true sigma
+  let sigma, cs = promote_forget_cases_algebraic env_pms off is_fwd (adj (shift p)) nargs o n sigma in
+  let unpacked =
+    apply_eliminator
+      {
+        elim;
+        pms = shift_all_by nargs (mk_n_rels npm);
+        p = shift_by nargs p;
+        cs = List.map adj cs;
+        final_args = mk_n_rels nargs;
+      }
   in
-  let sigma, forget =
-    if Option.has_some forget_o then
-      sigma, Option.get forget_o
-    else
-      find_promote_or_forget_algebraic env_pms idx indexer_n b a false sigma
-  in sigma, (promote, forget)
+  let o = (o_typ, arity_o) in
+  let n = (n_typ, arity_n) in
+  let idx = (npm + off, idx_t) in
+  let b = directional n o in
+  bind
+    (pack_orn f_indexer is_fwd env_p_o idx b unpacked)
+    (fun (env_packed, packed) ->
+      ret (reconstruct_lambda env_packed packed))
+    sigma
+
+(*
+ * Find promote and forget, using a directional flag for abstraction
+ *)
+let find_promote_forget_algebraic env_pms idx indexer_n promote_o forget_o a b =
+  find_promote_forget
+    (find_promote_or_forget_algebraic env_pms idx indexer_n a b)
+    promote_o
+    forget_o
               
 (*
  * Search two inductive types for an algebraic ornament between them
@@ -537,6 +549,253 @@ let search_algebraic env sigma npm indexer_n promote_o forget_o a b =
   let sigma, (promote, forget) = find_promote_forget_algebraic env_pms idx indexer_n promote_o forget_o a b sigma in
   sigma, { promote; forget; kind = Algebraic (indexer, fst idx + npm) }
 
+(* --- Swapping constructors --- *)
+
+(*
+ * This looks a lot like algebraic, except that there is no new index
+ * (and so no indexer and no packing/unpacking), but on the other hand we
+ * must swap the constructor order.
+ *
+ * There are sometimes many possible equivalences that correspond to this, so
+ * we start by enumerating the first n of those possible equivalences.
+ * We don't enumerate all because the total number of possible equivalences
+ * is, for each group of n_i constructors of the same type t_i, the product of
+ * all of the (n_i!).
+ *)
+
+(*
+ * Find all permutations of l that result from swapping either zero or one
+ * elements in the list. This is used to figure out which equivalences are
+ * possible and enumerate them in a reasonable order
+ *)
+let rec zero_one_swaps l =
+  match l with
+  | [] ->
+     []
+  | h :: [] ->
+     [[h]]
+  | h :: tl ->
+     let h_perms =
+       List.mapi
+         (fun i _ ->
+           let tl1, tl2 = split_at (i + 1) tl in
+           let h2 = last tl1 in
+           List.append (h2 :: all_but_last tl1) (h :: tl2))
+         tl
+     in List.append (List.map (fun l -> h :: l) (zero_one_swaps tl)) h_perms
+
+(*
+ * Also for reasonable enumeration order, we provide a way to filter out
+ * duplicate lists of swaps:
+ *)                    
+let same cs cs' =
+  List.for_all2 (fun c c' -> equal (mkConstructU c) (mkConstructU c')) cs cs'
+
+(*
+ * And a way of determining when we've visited a swap map before:
+ *)
+let visited seen swaps =
+  List.for_all
+    (fun swaps' -> not (same swaps' swaps))
+    seen
+  
+                
+(*
+ * Now we can get the n most likely swap maps. Most of the mess here is
+ * to enumerate those initial maps in a reasonable order. That means
+ * that this algorithm is not the most efficient for small lists,
+ * but we get a reasonable top 50 for large lists.
+ *
+ * The enumeration order here starts with zero swaps, then one swap,
+ * then two swaps, and so on, for each group of ambiguous constructors.
+ *)
+let rec get_likely_swap_maps n swaps =
+  (* Because of the strange enumeration order, we use fuel to terminate *)
+  let rec cs_swap_maps fuel seen cs_a cs_bs =
+    let swaps = List.map (List.combine cs_a) cs_bs in
+    if List.length swaps > n || fuel = 0 then
+      take n swaps
+    else
+      let cs_bs = List.filter (visited seen) (flat_map zero_one_swaps cs_bs) in
+      let cs_bs = unique same cs_bs in
+      let seen = List.append seen cs_bs in
+      take n (List.append swaps (cs_swap_maps (fuel - 1) seen cs_a cs_bs))
+  in
+  (* Now we do this for each group of ambiguous constructors *)
+  match swaps with
+  | (_, ((cs_a, cs_b), _)) :: tl ->
+     let swap_maps = get_likely_swap_maps n tl in
+     let swaps = cs_swap_maps (List.length cs_b - 1) [cs_b] cs_a [cs_b] in
+     if List.length swap_maps = 0 then
+       take n swaps
+     else
+       let swap_maps =
+         flat_map
+           (fun swap_map -> List.map (List.append swap_map) swaps)
+           swap_maps
+       in take n swap_maps
+  | _ ->
+     []
+
+(*
+ * OK, now when there are many possible maps, we prompot the user
+ * for more information and show them the top 50 that we found.
+ *
+ * Eventually, this would be better using Lemmas.add_lemma or something
+ * similar. For now, we just require the user to tell us which one
+ * using `Save ornament`.
+ *)
+let prompt_swap_ambiguous env swap_maps ambiguous sigma =
+  let num_solutions =
+    List.fold_left
+      (fun n (_, ((ms_o, _), _)) ->
+        if n = "1" then
+          Printf.sprintf "%d!" (List.length ms_o)
+        else
+          let len = List.length ms_o in
+          if len = 1 then
+            n
+          else
+            Printf.sprintf "%s * %d!" n len)
+      "1"
+      ambiguous
+  in
+  user_err
+    "prompt_swap_ambiguous"
+    (err_ambiguous_swap env num_solutions swap_maps sigma)
+    []
+    []
+
+(*
+ * OK, now that we've found that, we can find the actual equivalence.
+ *
+ * Find the motive for promote or forget for swapping constructors
+ *)
+let find_motive_swap env_motive typ nargs pms =
+  let typ_args = List.append (shift_all_by nargs pms) (mk_n_rels (nargs - 1)) in
+  let p_b = mkAppl (typ, typ_args) in
+  reconstruct_lambda_n env_motive p_b (List.length pms)
+
+(*
+ * Find the cases for promote or forget for swapping constructors
+ *)
+let find_cases_swap env p elim_p_typ swap_map o nargs sigma =
+  let env_p = push_local (Anonymous, p) env in
+  let ncons = List.length swap_map in
+  List.mapi
+    (fun i c ->
+      let env_c_b, c_b = zoom_product_type env_p c in
+      let (ind, u) = destInd o in
+      let constr_from = ((ind, (i + 1)), u) in
+      let constr_to = List.assoc constr_from swap_map in
+      let hyps =
+        List.mapi
+          (fun j rel ->
+            match rel with
+            | CRD.(LocalAssum (n, t)) ->
+               j + 1, shift_by (j + 1) t
+            | CRD.(LocalDef (n, e, t)) ->
+               j + 1, shift_by (j + 1) t)
+          (lookup_all_rels env_c_b)
+      in
+      let p_rel = first_fun c_b in
+      let constr_app = last_arg c_b in
+      let args = unfold_args constr_app in
+      let sigma, args_sub =
+        map_state
+          (fun arg sigma ->
+            try
+              let ih_i, _ =
+                List.find
+                  (fun (j, h_t) ->
+                    isApp h_t && applies p_rel h_t && equal (last_arg h_t) arg)
+                  hyps
+              in sigma, mkRel ih_i
+            with _ ->
+              sigma, arg)
+          args
+          sigma
+      in
+      let constr_ih = mkAppl (mkConstructU constr_to, args_sub) in
+      let c_p = reconstruct_lambda_n env_c_b constr_ih (nb_rel env_p) in
+      all_eq_substs (mkRel 1, shift_by nargs p) c_p)
+    (take ncons (factor_product elim_p_typ))
+        
+(*
+ * Find promote or forget for swapping constructors
+ *)
+let find_promote_or_forget_swap env npm swap_map a b is_fwd sigma =
+  let directional x y = if is_fwd then x else y in
+  let (o, n) = directional (a, b) (b, a) in
+  let swap_map = if is_fwd then swap_map else List.map reverse swap_map in
+  let elim = type_eliminator env (fst (destInd o)) in
+  let sigma, (env_pms, elim_typ) = on_type (fun env sigma t -> sigma, zoom_n_prod env npm t) env sigma elim in
+  let pms = mk_n_rels npm in
+  let (_, p_typ, elim_p_typ) = destProd elim_typ in
+  let env_p_b = zoom_env zoom_product_type env_pms p_typ in
+  let nargs = new_rels2 env_p_b env_pms in
+  let p = find_motive_swap env_p_b n nargs pms in
+  let cs = find_cases_swap env_pms p elim_p_typ swap_map o nargs sigma in
+  let app =
+    apply_eliminator
+      {
+        elim;
+        pms = shift_all_by nargs pms;
+        p = shift_by nargs p;
+        cs;
+        final_args = mk_n_rels nargs;
+      }
+  in sigma, reconstruct_lambda env_p_b app
+
+(*
+ * Find promote and forget for swapping constructors
+ *)
+let find_promote_forget_swap env npm swaps promote_o forget_o a b sigma =
+  let sigma, (promote, forget) =
+    find_promote_forget
+      (find_promote_or_forget_swap env npm swaps a b)
+      promote_o
+      forget_o
+      sigma
+  in
+  let swaps_ints = List.map (fun (((_, i), _), ((_, j), _)) -> i, j) swaps in
+  sigma, { promote ; forget ; kind = SwapConstruct swaps_ints }
+           
+(*
+ * Search for the components of the equivalence for swapping constructors
+ *)
+let search_swap_constructor env npm grouped swap_i_o promote_o forget_o a b sigma =
+  let sigma, swap_map =
+    if Option.has_some promote_o || Option.has_some forget_o then
+      swap_map_of_promote_or_forget env a b promote_o forget_o sigma
+    else
+      let swaps =
+        List.map
+          (fun (repr, (ms, typ_a)) ->
+            let (ms_a, ms_b) = List.partition (fun ((i, _), _) -> equal (mkInd i) a) ms in
+            let typ_b = all_eq_substs (a, b) typ_a in
+            (repr, ((List.rev ms_a, List.rev ms_b), (typ_a, typ_b))))
+          grouped
+      in
+      let ambiguous = List.filter (fun (_, ((ms_a, _), _)) -> List.length ms_a > 1) swaps in
+      if List.length ambiguous > 0 then
+        (* Ambiguous; need more information *)
+        let swap_maps = get_likely_swap_maps 50 swaps in
+        if Option.has_some swap_i_o then
+          (* The user gave us this information already *)
+          let swap_i = Option.get swap_i_o in
+          sigma, List.nth swap_maps swap_i
+        else
+          (* We ask the user to give us that information *)
+          sigma, prompt_swap_ambiguous env swap_maps ambiguous sigma
+      else
+        (* Unambiguous *)
+        map_state
+          (fun (_ , ((ms_a, ms_b), _)) -> ret (List.hd ms_a, List.hd ms_b))
+          swaps
+          sigma
+  in find_promote_forget_swap env npm swap_map promote_o forget_o a b sigma
+           
 (* --- Records and products --- *)
 
 (*
@@ -603,21 +862,12 @@ let find_promote_or_forget_curry_record env_pms a b is_fwd sigma =
 
 (*
  * Find both promote and forget for curry_record
- * TODO test, clean new option code
  *)
-let find_promote_forget_curry_record env_pms promote_o forget_o a b sigma =
-  let sigma, promote =
-    if Option.has_some promote_o then
-      sigma, Option.get promote_o
-    else
-      find_promote_or_forget_curry_record env_pms a b true sigma
-  in
-  let sigma, forget =
-    if Option.has_some forget_o then
-      sigma, Option.get forget_o
-    else
-      find_promote_or_forget_curry_record env_pms a b false sigma
-  in sigma, (promote, forget)
+let find_promote_forget_curry_record env_pms promote_o forget_o a b =
+  find_promote_forget
+    (find_promote_or_forget_curry_record env_pms a b)
+    promote_o
+    forget_o
 
 (*
  * Search for the components of the equivalence for curry_record
@@ -626,273 +876,12 @@ let search_curry_record env_pms sigma promote_o forget_o a b =
   let sigma, (promote, forget) = find_promote_forget_curry_record env_pms promote_o forget_o a b sigma in
   sigma, { promote; forget; kind = CurryRecord }
 
-(* --- Swapping constructors --- *)
-
-(*
- * TODO clean before merging
- *)
-
-let find_promote_or_forget_swap env npm swap_map a b is_fwd sigma =
-  let from_ind = if is_fwd then a else b in
-  let to_ind = if is_fwd then b else a in
-  let swap_map = if is_fwd then swap_map else List.map reverse swap_map in
-  let elim = type_eliminator env (fst (destInd from_ind)) in
-  let sigma, (env_pms, elim_typ) = on_type (fun env sigma t -> sigma, zoom_n_prod env npm t) env sigma elim in
-  let pms = mk_n_rels npm in
-  let (_, p_typ, elim_p_typ) = destProd elim_typ in
-  let env_p_b = zoom_env zoom_product_type env_pms p_typ in
-  let nargs = new_rels2 env_p_b env_pms in
-  let p = reconstruct_lambda_n env_p_b (mkAppl (to_ind, List.append (shift_all_by nargs pms) (mk_n_rels (nargs - 1)))) (nb_rel env_pms) in
-  let env_p = push_local (Anonymous, p) env_pms in
-  let ncons = List.length swap_map in
-  let cs =
-    List.mapi
-      (fun i c ->
-        let env_c_b, c_b = zoom_product_type env_p c in
-        let (ind, u) = destInd from_ind in
-        let constr_from = ((ind, (i + 1)), u) in
-        let constr_to = List.assoc constr_from swap_map in
-        (* TODO common functionality w/ algebraic *)
-        (* TODO clean a lot *)
-        let hyps =
-          List.mapi
-            (fun j rel ->
-              match rel with
-              | CRD.(LocalAssum (n, t)) ->
-                 j + 1, shift_by (j + 1) t
-              | CRD.(LocalDef (n, e, t)) ->
-                 j + 1, shift_by (j + 1) t)
-            (lookup_all_rels env_c_b)
-        in
-        let p_rel = first_fun c_b in
-        let constr_app = last_arg c_b in
-        let args = unfold_args constr_app in
-        let sigma, args_sub =
-          map_state
-            (fun arg sigma ->
-              try
-                let ih_i, _ =
-                  List.find
-                    (fun (j, h_t) ->
-                      isApp h_t && applies p_rel h_t && equal (last_arg h_t) arg)
-                    hyps
-                in sigma, mkRel ih_i
-              with _ ->
-                sigma, arg)
-            args
-            sigma
-        in
-        let constr_ih = mkAppl (mkConstructU constr_to, args_sub) in
-        let c_p = reconstruct_lambda_n env_c_b constr_ih (nb_rel env_p) in
-        all_eq_substs (mkRel 1, shift_by nargs p) c_p)
-      (take ncons (factor_product elim_p_typ))
-  in
-  let app =
-    apply_eliminator
-      {
-        elim;
-        pms = shift_all_by nargs pms;
-        p = shift_by nargs p;
-        cs;
-        final_args = mk_n_rels nargs;
-      }
-  in sigma, reconstruct_lambda env_p_b app
-
-let find_promote_forget_swap env npm swaps promote_o forget_o a b sigma =
-  let sigma, promote =
-    if Option.has_some promote_o then
-      sigma, Option.get promote_o
-    else
-      find_promote_or_forget_swap env npm swaps a b true sigma
-  in
-  let sigma, forget =
-    if Option.has_some forget_o then
-      sigma, Option.get forget_o
-    else
-      find_promote_or_forget_swap env npm swaps a b false sigma
-  in
-  let swaps_ints = List.map (fun (((_, i), _), ((_, j), _)) -> i, j) swaps in
-  sigma, { promote ; forget ; kind = SwapConstruct swaps_ints }
-
-let rec zero_one_swaps l =
-  match l with
-  | [] ->
-     []
-  | h :: [] ->
-     [[h]]
-  | h :: tl ->
-     let h_perms =
-       List.mapi
-         (fun i _ ->
-           let tl1, tl2 = split_at (i + 1) tl in
-           let h2 = last tl1 in
-           List.append (h2 :: all_but_last tl1) (h :: tl2))
-         tl
-     in List.append (List.map (fun l -> h :: l) (zero_one_swaps tl)) h_perms
-
-let same cs cs' =
-  List.for_all2 (fun c c' -> equal (mkConstructU c) (mkConstructU c')) cs cs'
-             
-(*
- * TODO clean, explain
- * note that the enumeration order here means the alg is deliberately
- * not most efficient for small lists, but this is to let us
- * return a reasonable top 50 for large lists
- *)
-let rec get_likely_swap_maps n swaps : ((pconstructor * pconstructor) list) list =
-  match swaps with
-  | (_, ((ms_a, ms_b), _)) :: tl ->
-     let swap_maps = get_likely_swap_maps n tl in
-     let rec cs_swap_maps fuel acc ms_b_swaps =
-       let swaps = List.map (List.combine ms_a) ms_b_swaps in
-       if List.length swaps > n then
-         take n swaps
-       else if fuel = 0 then
-         take n swaps
-       else
-         let ms_b_swaps = List.filter (fun ms_b_swaps' -> List.for_all (fun ms_b_swaps -> not (same ms_b_swaps ms_b_swaps')) acc) (flat_map zero_one_swaps ms_b_swaps) in
-         let ms_b_swaps = unique same ms_b_swaps in
-         take n (List.append swaps (cs_swap_maps (fuel - 1) (List.append acc ms_b_swaps) ms_b_swaps))
-     in
-     let swaps = cs_swap_maps (List.length ms_b - 1) [ms_b] [ms_b] in
-     if List.length swap_maps = 0 then
-       take n swaps
-     else
-       let swap_maps =
-         flat_map
-           (fun swap_map -> List.map (List.append swap_map) swaps)
-           swap_maps
-       in take n swap_maps
-  | _ ->
-     []
-
-(*
- * TODO at some point, port to using Lemmas.add_lemma or something similar.
- * For now, just require the user to tell us which one via config.
- * Also could just have a `Configure Search` or `Configure Find ornament`
- * or somethign like that, or could have an option. Whatever is best
- * engineering + user experience together.
- *
- * TODO also clean lots obvs
- *)
-let prompt_swap_ambiguous env swap_maps ambiguous sigma =
-  let num_solutions =
-    List.fold_left
-      (fun n (_, ((ms_o, _), _)) ->
-        if n = "1" then
-          Printf.sprintf "%d!" (List.length ms_o)
-        else
-          let len = List.length ms_o in
-          if len = 1 then
-            n
-          else
-            Printf.sprintf "%s * %d!" n (List.length ms_o))
-      "1"
-      ambiguous
-  in
-  let print_swap_map i swap_map =
-    Pp.seq
-      [Pp.int i;
-       Pp.str ") ";
-       (Pp.prlist_with_sep
-          (fun _ -> Pp.str ", ")
-          (fun (c_o, c_n) ->
-            Pp.prlist_with_sep
-              (fun _ -> Pp.str " <-> ")
-              (Printer.pr_constr_env env sigma)
-              [mkConstructU c_o; mkConstructU c_n])
-          swap_map);
-      Pp.fnl ()]
-  in
-  CErrors.user_err
-    (Pp.seq
-       [Pp.str "DEVOID found ";
-        Pp.str num_solutions;
-        Pp.str " possible mappings for constructors. ";
-        Pp.str "Showing up to the first 50:";
-        Pp.fnl ();
-        Pp.seq (List.mapi print_swap_map swap_maps);
-        Pp.fnl ();
-        Pp.str "Please choose the mapping you'd like to use. ";
-        Pp.str "Then, pass that to DEVOID by calling `Find ornament` again. ";
-        Pp.str "For example: `Find ornament old new { mapping 0 }`. ";
-        Pp.str "If the mapping you want is not in the 50 shown, ";
-        Pp.str "please pass the mapping to `Save ornament` instead."])
-
-(*
- * Search for the components of the equivalence for swapping constructors
- *)
-let search_swap_constructor env npm grouped swap_i_o promote_o forget_o a b sigma =
-  (* TODO refactor common w/ lifting (get_kind_of_ornament) *)
-  let trm_o_o = if Option.has_some promote_o then promote_o else forget_o in
-  let sigma, swap_map =
-    if Option.has_some trm_o_o then
-      (* Infer swap map from promotion function *)
-      let f = Option.get trm_o_o in
-      let ((i_o, ii_o), u_o) = destInd (if Option.has_some promote_o then a else b) in
-      let m_o = lookup_mind i_o env in
-      let b_o = m_o.mind_packets.(0) in
-      let cs_o = b_o.mind_consnames in
-      let ncons = Array.length cs_o in
-      let sigma, swap_map =
-        map_state
-          (fun i sigma ->
-            let c_o = mkConstructU (((i_o, ii_o), i), u_o) in
-            let sigma, c_o_typ = reduce_type env sigma c_o in
-            let env_c_o, c_o_typ = zoom_product_type env c_o_typ in
-            let nargs = new_rels2 env_c_o env in
-            let c_o_args = mk_n_rels nargs in
-            let c_o_app = mkAppl (c_o, c_o_args) in
-            let typ_args = unfold_args c_o_typ in
-            let sigma, c_o_lifted = reduce_nf env_c_o sigma (mkAppl (f, snoc c_o_app typ_args)) in
-            let swap = ((((i_o, ii_o), i), u_o), destConstruct (first_fun c_o_lifted)) in
-            if Option.has_some promote_o then
-              sigma, swap
-            else
-              sigma, reverse swap)
-          (range 1 (ncons + 1))
-          sigma
-      in sigma, swap_map
-    else
-      (* Determine swap map *)
-      let swaps =
-        List.map
-          (fun (repr, (ms, typ_a)) ->
-            let (ms_a, ms_b) = List.partition (fun ((i, _), _) -> equal (mkInd i) a) ms in
-            let typ_b = all_eq_substs (a, b) typ_a in
-            (repr, ((List.rev ms_a, List.rev ms_b), (typ_a, typ_b))))
-          grouped
-      in
-      let ambiguous = List.filter (fun (_, ((ms_a, _), _)) -> List.length ms_a > 1) swaps in
-      if List.length ambiguous > 0 then
-        (* Ambiguous; need more information *)
-        let swap_maps = get_likely_swap_maps 50 swaps in
-        if Option.has_some swap_i_o then
-          (* The user gave us this information already *)
-          let swap_i = Option.get swap_i_o in
-          sigma, List.nth swap_maps swap_i
-        else
-          (* We ask the user to give us that information *)
-          sigma, prompt_swap_ambiguous env swap_maps ambiguous sigma
-      else
-        (* Unambiguous *)
-        map_state
-          (fun (_ , ((ms_a, ms_b), _)) -> ret (List.hd ms_a, List.hd ms_b))
-          swaps
-          sigma
-  in find_promote_forget_swap env npm swap_map promote_o forget_o a b sigma
-
 (* --- Top-level search --- *)
 
 (*
  * Search two inductive types for an ornament between them.
  * This is more general to handle eventual extension with other 
  * kinds of ornaments.
- *
- * TODO move swap_i_o, indexer_id_opt, etc to some kind of configuration for Find ornament. Or, infer swap_map seperately before you get to search, for example
- * in differencing, and make it possible to pass one there.
- *
- * TODO somehow move "forget_only" to invert
  *)
 let search_orn_inductive env sigma indexer_id_opt swap_i_o typ_o typ_n promote_o forget_o =
   match map_tuple kind (typ_o, typ_n) with

--- a/plugin/src/automation/search.mli
+++ b/plugin/src/automation/search.mli
@@ -12,9 +12,7 @@ open Stateutils
 (* --- Top-level search --- *)
 
 (* 
- * Search two types for an ornamental promotion between them
- * Automatically infer the kind of change
- * Automatically infer the new index
+ * Search for an ornamental promotion between two types
  *)
 val search_orn :
   env ->
@@ -25,3 +23,19 @@ val search_orn :
   types -> (* new type *)
   promotion state (* ornamental promotion *)
 
+(* 
+ * Try to invert a single component of an ornamental promotion isomorphism
+ * (Like search, but only in one direction)
+ *
+ * Exactly one of promote and forget must be present, otherwise this fails
+ *)
+val invert_orn :
+  env ->
+  evar_map ->
+  Id.t option -> (* name to assign the indexer function, if relevant *)
+  int option -> (* TODO move me *)
+  types -> (* old type *)
+  types -> (* new type *)
+  constr option -> (* optional promotion function *)
+  constr option -> (* optional forgetful function *)
+  promotion state (* ornamental promotion *)

--- a/plugin/src/automation/search.mli
+++ b/plugin/src/automation/search.mli
@@ -8,7 +8,7 @@ open Evd
 open Names
 open Promotion
 open Stateutils
-       
+
 (* --- Top-level search --- *)
 
 (* 
@@ -18,7 +18,7 @@ val search_orn :
   env ->
   evar_map ->
   Id.t option -> (* name to assign the indexer function, if relevant *)
-  int option -> (* TODO move me *)
+  int option -> (* offset of swap map, if relevant *)
   types -> (* old type *)
   types -> (* new type *)
   promotion state (* ornamental promotion *)
@@ -33,7 +33,7 @@ val invert_orn :
   env ->
   evar_map ->
   Id.t option -> (* name to assign the indexer function, if relevant *)
-  int option -> (* TODO move me *)
+  int option -> (* offset of swap map, if relevant *)
   types -> (* old type *)
   types -> (* new type *)
   constr option -> (* optional promotion function *)

--- a/plugin/src/automation/search.mli
+++ b/plugin/src/automation/search.mli
@@ -8,7 +8,7 @@ open Evd
 open Names
 open Promotion
 open Stateutils
-
+       
 (* --- Top-level search --- *)
 
 (* 

--- a/plugin/src/automation/search.mli
+++ b/plugin/src/automation/search.mli
@@ -20,6 +20,7 @@ val search_orn :
   env ->
   evar_map ->
   Id.t option -> (* name to assign the indexer function, if relevant *)
+  int option -> (* TODO move me *)
   types -> (* old type *)
   types -> (* new type *)
   promotion state (* ornamental promotion *)

--- a/plugin/src/frontend.ml
+++ b/plugin/src/frontend.ml
@@ -76,7 +76,7 @@ let maybe_prove_equivalence n inv_n : unit =
   if is_search_equiv () then
     let sigma, env = refresh_env () in
     let (promote, forget) = map_tuple make_constant (n, inv_n) in
-    let l = initialize_lifting env sigma promote forget in
+    let sigma, l = initialize_lifting env sigma promote forget in
     let (section, retraction) = prove_equivalence env sigma l in
     let sect = define_proof "section" sigma section in
     let retr0 = define_proof "retraction" sigma retraction in
@@ -180,7 +180,7 @@ let save_ornament d_old d_new d_orn d_orn_inv =
   let sigma, def_n = intern env sigma d_new in
   let trm_o, trm_n = map_tuple (try_delta_inductive env) (def_o, def_n) in
   try
-    let l = initialize_lifting env sigma promote forget in
+    let sigma, l = initialize_lifting env sigma promote forget in
     save_ornament (trm_o, trm_n) (promote, forget, l.orn.kind)
   with _ ->
     user_err
@@ -195,6 +195,8 @@ let save_ornament d_old d_new d_orn d_orn_inv =
  *)
 let lift_definition_by_ornament env sigma n l c_old ignores =
   let sigma, lifted = do_lift_defn env sigma l c_old ignores in
+  let open Printing in
+  debug_term env lifted "lifted";
   try
     ignore
       (if is_lift_type () then
@@ -268,7 +270,7 @@ let init_lift env d_orn d_orn_inv sigma =
       (* The ornament is cached *)
       sigma, env
   in
-  let l = initialize_lifting env sigma o n in
+  let sigma, l = initialize_lifting env sigma o n in
   sigma, (env, l)
 
 (*

--- a/plugin/src/frontend.ml
+++ b/plugin/src/frontend.ml
@@ -195,8 +195,6 @@ let save_ornament d_old d_new d_orn d_orn_inv =
  *)
 let lift_definition_by_ornament env sigma n l c_old ignores =
   let sigma, lifted = do_lift_defn env sigma l c_old ignores in
-  let open Printing in
-  debug_term env lifted "lifted";
   try
     ignore
       (if is_lift_type () then

--- a/plugin/src/frontend.ml
+++ b/plugin/src/frontend.ml
@@ -77,7 +77,7 @@ let maybe_prove_equivalence n inv_n : unit =
   if is_search_equiv () then
     let sigma, env = refresh_env () in
     let (promote, forget) = map_tuple make_constant (n, inv_n) in
-    let sigma, l = initialize_lifting env sigma promote forget in
+    let sigma, l = initialize_lifting_provided env sigma promote forget in
     let (section, retraction) = prove_equivalence env sigma l in
     let sect = define_proof "section" sigma section in
     let retr0 = define_proof "retraction" sigma retraction in
@@ -180,8 +180,9 @@ let find_ornament n_o d_old d_new swap_i_o =
 (*
  * Save a user-provided ornament
  *)
-let save_ornament d_old d_new d_orn d_orn_inv =
+let save_ornament d_old d_new d_orn d_orn_inv_o =
   Feedback.msg_warning (Pp.str "Custom equivalences are experimental. Use at your own risk!");
+  let d_orn_inv = Option.get d_orn_inv_o in (* TODO implement None case *)
   let (sigma, env) = Pfedit.get_current_context () in
   let sigma, promote = intern env sigma d_orn in
   let sigma, forget = intern env sigma d_orn_inv in
@@ -189,7 +190,7 @@ let save_ornament d_old d_new d_orn d_orn_inv =
   let sigma, def_n = intern env sigma d_new in
   let trm_o, trm_n = map_tuple (try_delta_inductive env) (def_o, def_n) in
   try
-    let sigma, l = initialize_lifting env sigma promote forget in
+    let sigma, l = initialize_lifting_provided env sigma promote forget in
     save_ornament (trm_o, trm_n) (promote, forget, l.orn.kind)
   with _ ->
     user_err
@@ -277,7 +278,7 @@ let init_lift env d_orn d_orn_inv sigma =
       (* The ornament is cached *)
       sigma, env
   in
-  let sigma, l = initialize_lifting env sigma o n in
+  let sigma, l = initialize_lifting_cached env sigma o n in
   sigma, (env, l)
 
 (*

--- a/plugin/src/frontend.ml
+++ b/plugin/src/frontend.ml
@@ -96,7 +96,7 @@ let maybe_prove_equivalence n inv_n : unit =
     ()
 
 (*
- * TODO comment, clean, common code, etc
+ * Common function for find_ornament and save_ornament
  *)
 let find_ornament_common env n_o d_old d_new swap_i_o promote_o forget_o sigma =
   try
@@ -218,7 +218,7 @@ let save_ornament d_old d_new d_orn_o d_orn_inv_o =
   Feedback.msg_warning (Pp.str "Custom equivalences are experimental. Use at your own risk!");
   let (sigma, env) = Pfedit.get_current_context () in
   if not (Option.has_some d_orn_o || Option.has_some d_orn_inv_o) then
-    CErrors.user_err (str "Please provide a promotion or forgetful function") (* TODO better error message using utils *)
+    CErrors.user_err (str "Please provide a promotion or forgetful function")
   else
     let maybe_intern def_o sigma =
       if Option.has_some def_o then

--- a/plugin/src/frontend.ml
+++ b/plugin/src/frontend.ml
@@ -99,7 +99,7 @@ let maybe_prove_equivalence n inv_n : unit =
  * Define the components of the corresponding equivalence
  * If the appropriate option is set, prove these components form an equivalence
  *)
-let find_ornament n_o d_old d_new =
+let find_ornament n_o d_old d_new swap_i_o =
   try
     let (sigma, env) = Pfedit.get_current_context () in
     let sigma, def_o = intern env sigma d_old in
@@ -134,7 +134,7 @@ let find_ornament n_o d_old d_new =
             [try_supported; try_provide]
             [cool_feature; mistake]
     in
-    let sigma, orn = search_orn env sigma idx_n trm_o trm_n in
+    let sigma, orn = search_orn env sigma idx_n swap_i_o trm_o trm_n in
     let orn =
       match orn.kind with
       | Algebraic (indexer, off) ->

--- a/plugin/src/frontend.mli
+++ b/plugin/src/frontend.mli
@@ -6,7 +6,7 @@ open Names
  * Define the components of the corresponding equivalence
  * If the appropriate option is set, prove that these form an equivalence
  *)
-val find_ornament : Id.t option -> constr_expr -> constr_expr -> unit          
+val find_ornament : Id.t option -> constr_expr -> constr_expr -> int option -> unit          
 
 (*
  * Save a user-supplied ornament between two types

--- a/plugin/src/frontend.mli
+++ b/plugin/src/frontend.mli
@@ -10,9 +10,11 @@ val find_ornament : Id.t option -> constr_expr -> constr_expr -> int option -> u
 
 (*
  * Save a user-supplied ornament between two types
+ * If only one of two function is supplied, automatically invert
+ * If the appropriate option is set, prove that these form an equivalence
  *)
 val save_ornament :
-  constr_expr -> constr_expr -> constr_expr -> constr_expr option -> unit
+  constr_expr -> constr_expr -> constr_expr option -> constr_expr option -> unit
                                                                    
 (*
  * Lift the supplied function along an ornament between the supplied types

--- a/plugin/src/frontend.mli
+++ b/plugin/src/frontend.mli
@@ -12,7 +12,7 @@ val find_ornament : Id.t option -> constr_expr -> constr_expr -> int option -> u
  * Save a user-supplied ornament between two types
  *)
 val save_ornament :
-  constr_expr -> constr_expr -> constr_expr -> constr_expr -> unit
+  constr_expr -> constr_expr -> constr_expr -> constr_expr option -> unit
                                                                    
 (*
  * Lift the supplied function along an ornament between the supplied types

--- a/plugin/src/lib/ornerrors.ml
+++ b/plugin/src/lib/ornerrors.ml
@@ -1,6 +1,7 @@
 open Utilities
 open CErrors
 open Himsg
+open Constr
 
 (* 
  * Errors and error messages
@@ -48,6 +49,36 @@ let err_type env sigma err =
      Pp.str "2. during lifting, the term contains match statements that are not preprocessed.";
      Pp.str "3. during search or lifting, a type or term is not supported, but we do not correctly detect this."]
 
+let err_ambiguous_swap env num_solutions swap_maps sigma =
+  let print_swap_map i swap_map =
+    Pp.seq
+      [Pp.int i;
+       Pp.str ") ";
+       (Pp.prlist_with_sep
+          (fun _ -> Pp.str ", ")
+          (fun (c_o, c_n) ->
+            Pp.prlist_with_sep
+              (fun _ -> Pp.str " <-> ")
+              (Printer.pr_constr_env env sigma)
+              [mkConstructU c_o; mkConstructU c_n])
+          swap_map);
+       Pp.fnl ()]
+  in
+  Pp.seq
+    [Pp.str "DEVOID found ";
+     Pp.str num_solutions;
+     Pp.str " possible mappings for constructors. ";
+     Pp.str "Showing up to the first 50:";
+     Pp.fnl ();
+     Pp.seq (List.mapi print_swap_map swap_maps);
+     Pp.fnl ();
+     Pp.str "Please choose the mapping you'd like to use. ";
+     Pp.str "Then, pass that to DEVOID by calling `Find ornament` again. ";
+     Pp.str "For example: `Find ornament old new { mapping 0 }`. ";
+     Pp.str "If the mapping you want is not in the 50 shown, ";
+     Pp.str "please pass the mapping to `Save ornament` instead."]
+
+  
 (* --- Possible workaround suggestions --- *)
 
 let try_opaque = Pp.str "skipping subterms using the `{ opaque ... }` option"

--- a/plugin/src/lib/ornerrors.mli
+++ b/plugin/src/lib/ornerrors.mli
@@ -1,5 +1,6 @@
 open Environ
 open Evd
+open Constr
 
 (*
  * Errors and error messages
@@ -20,6 +21,8 @@ val err_save_ornament : Pp.t
 val err_unexpected_change : String.t -> Pp.t
 val err_type : env -> evar_map -> Pretype_errors.pretype_error -> Pp.t
 val err_opaque_not_constant : Libnames.qualid -> Pp.t
+val err_ambiguous_swap :
+  env -> string -> ((pconstructor * pconstructor) list) list -> evar_map -> Pp.t
 
 (* --- Possible workaround suggestions --- *)
 

--- a/plugin/src/ornamental.ml4
+++ b/plugin/src/ornamental.ml4
@@ -6,9 +6,13 @@ open Frontend
 (* Identify an ornament given two types *)
 VERNAC COMMAND EXTEND FindOrnament CLASSIFIED AS SIDEFF
 | [ "Find" "ornament" constr(d_old) constr(d_new) "as" ident(n) ] ->
-  [ find_ornament (Some n) d_old d_new ]
+  [ find_ornament (Some n) d_old d_new None ]
+| [ "Find" "ornament" constr(d_old) constr(d_new) "as" ident(n) "{" "mapping" int(i) "}" ] ->
+  [ find_ornament (Some n) d_old d_new (Some i) ]
 | [ "Find" "ornament" constr(d_old) constr(d_new) ] ->
-  [ find_ornament None d_old d_new ]
+  [ find_ornament None d_old d_new None ]
+| [ "Find" "ornament" constr(d_old) constr(d_new) "{" "mapping" int(i) "}" ] ->
+  [ find_ornament None d_old d_new (Some i) ]
 END
 
 (* Save a user-supplied ornament between two types *)

--- a/plugin/src/ornamental.ml4
+++ b/plugin/src/ornamental.ml4
@@ -18,7 +18,9 @@ END
 (* Save a user-supplied ornament between two types *)
 VERNAC COMMAND EXTEND SaveOrnament CLASSIFIED AS SIDEFF
 | [ "Save" "ornament" constr(d_old) constr(d_new) "{" "promote" "=" constr(d_orn) ";" "forget" "=" constr(d_orn_inv) "}" ] ->
-  [ save_ornament d_old d_new d_orn d_orn_inv ]
+  [ save_ornament d_old d_new d_orn (Some d_orn_inv) ]
+| [ "Save" "ornament" constr(d_old) constr(d_new) "{" "promote" "=" constr(d_orn) "}" ] ->
+  [ save_ornament d_old d_new d_orn None ]
 END
 
 (* Lift a function along an ornament *)

--- a/plugin/src/ornamental.ml4
+++ b/plugin/src/ornamental.ml4
@@ -18,9 +18,11 @@ END
 (* Save a user-supplied ornament between two types *)
 VERNAC COMMAND EXTEND SaveOrnament CLASSIFIED AS SIDEFF
 | [ "Save" "ornament" constr(d_old) constr(d_new) "{" "promote" "=" constr(d_orn) ";" "forget" "=" constr(d_orn_inv) "}" ] ->
-  [ save_ornament d_old d_new d_orn (Some d_orn_inv) ]
+  [ save_ornament d_old d_new (Some d_orn) (Some d_orn_inv) ]
 | [ "Save" "ornament" constr(d_old) constr(d_new) "{" "promote" "=" constr(d_orn) "}" ] ->
-  [ save_ornament d_old d_new d_orn None ]
+  [ save_ornament d_old d_new (Some d_orn) None ]
+| [ "Save" "ornament" constr(d_old) constr(d_new) "{" "forget" "=" constr(d_orn_inv) "}" ] ->
+  [ save_ornament d_old d_new None (Some d_orn_inv) ]
 END
 
 (* Lift a function along an ornament *)
@@ -51,6 +53,4 @@ END
 VERNAC COMMAND EXTEND UnpackSigma CLASSIFIED AS SIDEFF
 | [ "Unpack" reference(const_ref) "as" ident(id) ] ->
   [ do_unpack_constant id const_ref ]
-(* | [ "Unpack" "Module" reference(mod_ref) "as" ident(id) ] ->
- *   [ do_unpack_module id mod_ref ] *)
 END

--- a/plugin/src/ornaments/lifting.ml
+++ b/plugin/src/ornaments/lifting.ml
@@ -86,7 +86,7 @@ let direction_cached env from_typ to_typ k : bool =
   | CurryRecord ->
      isInd from_typ
   | SwapConstruct _ ->
-     failwith "not yet implemented"
+     true (* TODO!!! will fail in bwd direction, need to implement something to distinguish directions for this *)
 
 (* 
  * Unpack a promotion
@@ -97,9 +97,6 @@ let unpack_promotion env promotion =
 
 (*
  * Get the direction for an uncached ornament.
- * For now, we use a boolean for is_algebraic, but in the long run, we should
- * take a kind here. This is a bit tricky since we need the direction right
- * now in order to construct the kind.
  *)
 let get_direction (from_typ_app, to_typ_app) orn_kind =
   match orn_kind with
@@ -117,7 +114,7 @@ let get_direction (from_typ_app, to_typ_app) orn_kind =
   | CurryRecord ->
      not (equal Produtils.prod (first_fun from_typ_app))
   | SwapConstruct _ ->
-     failwith "not yet implemented"
+     true
 
 (*
  * For an uncached ornament, get the kind and its direction
@@ -147,7 +144,8 @@ let get_kind_of_ornament env (o, n) sigma =
      let is_fwd = get_direction (from_typ_app, to_typ_app) prelim_kind in
      is_fwd, CurryRecord
   | SwapConstruct _ ->
-     failwith "not yet implemented"
+     (* TODO implement; won't work for save ornament, or for bwd *)
+     true, prelim_kind
 
 (* --- Initialization --- *)
 

--- a/plugin/src/ornaments/lifting.ml
+++ b/plugin/src/ornaments/lifting.ml
@@ -187,10 +187,10 @@ let initialize_lifting_cached env sigma o n =
  * Initialize a lifting for a user-provided ornament
  * TODO take an option and try to automatically invert if not there;
  * fail gracefully. 
- * TODO auto equiv proof if option set
  *)
-let initialize_lifting_provided env sigma o n =
+let initialize_lifting_provided env sigma o n_o =
   let sigma, (is_fwd, (promote, forget), kind) =
+    let n = Option.get n_o in
     let sigma, (is_fwd, k) = get_kind_of_ornament env (o, n) sigma in
     let orns = map_if reverse (not is_fwd) (o, n) in
     sigma, (is_fwd, orns, k)

--- a/plugin/src/ornaments/lifting.ml
+++ b/plugin/src/ornaments/lifting.ml
@@ -128,7 +128,7 @@ let get_kind_of_ornament env (o, n) sigma =
     if applies sigT from_typ_app || applies sigT to_typ_app then
       Algebraic (mkRel 1, 0)
     else if isInd (first_fun from_typ_app) && isInd (first_fun to_typ_app) then
-      SwapConstruct (0, 0)
+      SwapConstruct []
     else
       CurryRecord
   in

--- a/plugin/src/ornaments/lifting.ml
+++ b/plugin/src/ornaments/lifting.ml
@@ -185,12 +185,9 @@ let initialize_lifting_cached env sigma o n =
 
 (*
  * Initialize a lifting for a user-provided ornament
- * TODO take an option and try to automatically invert if not there;
- * fail gracefully.
  *)
-let initialize_lifting_provided env sigma o n_o =
+let initialize_lifting_provided env sigma o n =
   let sigma, (is_fwd, (promote, forget), kind) =
-    let n = Option.get n_o in
     let sigma, (is_fwd, k) = get_kind_of_ornament env (o, n) sigma in
     let orns = map_if reverse (not is_fwd) (o, n) in
     sigma, (is_fwd, orns, k)

--- a/plugin/src/ornaments/lifting.ml
+++ b/plugin/src/ornaments/lifting.ml
@@ -142,8 +142,6 @@ let get_kind_of_ornament env (o, n) sigma =
   | SwapConstruct _ ->
      let promote = o in
      let sigma, promote_type = reduce_type env sigma promote in
-     let env_promote = zoom_env zoom_product_type env promote_type in
-     let typ_args = unfold_args from_typ_app in
      let ((i_o, ii_o), u_o) = destInd (first_fun from_typ_app) in
      let m_o = lookup_mind i_o env in
      let b_o = m_o.mind_packets.(0) in
@@ -154,12 +152,12 @@ let get_kind_of_ornament env (o, n) sigma =
          (fun i sigma ->
            let c_o = mkConstructU (((i_o, ii_o), i), u_o) in
            let sigma, c_o_typ = reduce_type env sigma c_o in
-           let env_c_o = zoom_env zoom_product_type env c_o_typ in
-           let nargs = new_rels2 env_c_o env_promote in
+           let env_c_o, c_o_typ = zoom_product_type env c_o_typ in
+           let nargs = new_rels2 env_c_o env in
            let c_o_args = mk_n_rels nargs in
            let c_o_app = mkAppl (c_o, c_o_args) in
-           let typ_args = shift_all_by nargs typ_args in
-           let sigma, c_o_lifted = reduce_nf env sigma (mkAppl (promote, snoc c_o_app typ_args)) in
+           let typ_args = unfold_args c_o_typ in
+           let sigma, c_o_lifted = reduce_nf env_c_o sigma (mkAppl (promote, snoc c_o_app typ_args)) in
            let ((_, j), _) = destConstruct (first_fun c_o_lifted) in
            sigma, (i, j))
          (range 1 (ncons + 1))

--- a/plugin/src/ornaments/lifting.ml
+++ b/plugin/src/ornaments/lifting.ml
@@ -186,7 +186,7 @@ let initialize_lifting_cached env sigma o n =
 (*
  * Initialize a lifting for a user-provided ornament
  * TODO take an option and try to automatically invert if not there;
- * fail gracefully. 
+ * fail gracefully.
  *)
 let initialize_lifting_provided env sigma o n_o =
   let sigma, (is_fwd, (promote, forget), kind) =

--- a/plugin/src/ornaments/lifting.mli
+++ b/plugin/src/ornaments/lifting.mli
@@ -24,13 +24,26 @@ type lifting =
 (* --- Initialization --- *)
 
 (*
- * Initialize a lifting, given (in order):
+ * Initialize a lifting for a cached ornament, given (in order):
  * 1) an environment
  * 2) an evar_map
- * 3) the old type or user-supplied ornament function
- * 4) the new type or user-supplied ornament function
+ * 3) the old type
+ * 4) the new type
  *)
-val initialize_lifting : env -> evar_map -> types -> types -> lifting state
+val initialize_lifting_cached :
+  env -> evar_map -> types -> types -> lifting state
+
+(*
+ * Initialize a lifting for a user-supplied ornament, given (in order):
+ * 1) an environment
+ * 2) an evar_map
+ * 3) the old user-supplied ornament function
+ * 4) the new user-supplied ornament function
+ *
+ * TODO update comment once takes an option
+ *)
+val initialize_lifting_provided :
+  env -> evar_map -> types -> types -> lifting state
 
 (* --- Control structures --- *)
     

--- a/plugin/src/ornaments/lifting.mli
+++ b/plugin/src/ornaments/lifting.mli
@@ -38,12 +38,10 @@ val initialize_lifting_cached :
  * 1) an environment
  * 2) an evar_map
  * 3) the old user-supplied ornament function
- * 4) optionally, the new user-supplied ornament function
- *
- * TODO update comment once takes an option
+ * 4) the new user-supplied ornament function
  *)
 val initialize_lifting_provided :
-  env -> evar_map -> types -> types option -> lifting state
+  env -> evar_map -> types -> types -> lifting state
 
 (* --- Control structures --- *)
     

--- a/plugin/src/ornaments/lifting.mli
+++ b/plugin/src/ornaments/lifting.mli
@@ -6,6 +6,7 @@ open Constr
 open Environ
 open Evd
 open Promotion
+open Stateutils
 
 (* --- Datatypes --- *)
 
@@ -29,7 +30,7 @@ type lifting =
  * 3) the old type or user-supplied ornament function
  * 4) the new type or user-supplied ornament function
  *)
-val initialize_lifting : env -> evar_map -> types -> types -> lifting
+val initialize_lifting : env -> evar_map -> types -> types -> lifting state
 
 (* --- Control structures --- *)
     

--- a/plugin/src/ornaments/lifting.mli
+++ b/plugin/src/ornaments/lifting.mli
@@ -20,7 +20,7 @@ type lifting =
     orn : promotion;
     is_fwd : bool;
   }
-
+    
 (* --- Initialization --- *)
 
 (*
@@ -41,7 +41,7 @@ val initialize_lifting_cached :
  * 4) the new user-supplied ornament function
  *)
 val initialize_lifting_provided :
-  env -> evar_map -> types -> types -> lifting state
+  env -> evar_map -> constr -> constr -> lifting state
 
 (* --- Control structures --- *)
     

--- a/plugin/src/ornaments/lifting.mli
+++ b/plugin/src/ornaments/lifting.mli
@@ -38,12 +38,12 @@ val initialize_lifting_cached :
  * 1) an environment
  * 2) an evar_map
  * 3) the old user-supplied ornament function
- * 4) the new user-supplied ornament function
+ * 4) optionally, the new user-supplied ornament function
  *
  * TODO update comment once takes an option
  *)
 val initialize_lifting_provided :
-  env -> evar_map -> types -> types -> lifting state
+  env -> evar_map -> types -> types option -> lifting state
 
 (* --- Control structures --- *)
     

--- a/plugin/src/ornaments/promotion.ml
+++ b/plugin/src/ornaments/promotion.ml
@@ -1,4 +1,12 @@
 open Constr
+open Declarations
+open Stateutils
+open Reducers
+open Zooming
+open Envutils
+open Apputils
+open Utilities
+open Environ
 
 (* --- Ornamental promotions --- *)
 
@@ -20,3 +28,32 @@ type promotion =
     forget : types;
     kind : kind_of_orn;
   }
+
+(*
+ * Get the swap map from the promotion or forgetful function, if one
+ * is provided
+ *)
+let swap_map_of_promote_or_forget env a b promote_o forget_o =
+  let trm_o_o = if Option.has_some promote_o then promote_o else forget_o in
+  let f = Option.get trm_o_o in
+  let ((i_o, ii_o), u_o) = destInd (if Option.has_some promote_o then a else b) in
+  let m_o = lookup_mind i_o env in
+  let b_o = m_o.mind_packets.(0) in
+  let cs_o = b_o.mind_consnames in
+  let ncons = Array.length cs_o in
+  map_state
+    (fun i sigma ->
+      let c_o = mkConstructU (((i_o, ii_o), i), u_o) in
+      let sigma, c_o_typ = reduce_type env sigma c_o in
+      let env_c_o, c_o_typ = zoom_product_type env c_o_typ in
+      let nargs = new_rels2 env_c_o env in
+      let c_o_args = mk_n_rels nargs in
+      let c_o_app = mkAppl (c_o, c_o_args) in
+      let typ_args = unfold_args c_o_typ in
+      let sigma, c_o_lifted = reduce_nf env_c_o sigma (mkAppl (f, snoc c_o_app typ_args)) in
+      let swap = ((((i_o, ii_o), i), u_o), destConstruct (first_fun c_o_lifted)) in
+      if Option.has_some promote_o then
+        sigma, swap
+      else
+        sigma, reverse swap)
+    (range 1 (ncons + 1))  

--- a/plugin/src/ornaments/promotion.ml
+++ b/plugin/src/ornaments/promotion.ml
@@ -8,7 +8,7 @@ open Constr
 type kind_of_orn =
   | Algebraic of constr * int
   | CurryRecord
-  | SwapConstruct of int * int
+  | SwapConstruct of (int * int) list
 
 (*
  * An ornamental promotion is a function from T1 -> T2,

--- a/plugin/src/ornaments/promotion.ml
+++ b/plugin/src/ornaments/promotion.ml
@@ -52,5 +52,5 @@ let swap_map_of_promote_or_forget env a b promote_o forget_o =
       let typ_args = unfold_args c_o_typ in
       let sigma, c_o_lifted = reduce_nf env_c_o sigma (mkAppl (f, snoc c_o_app typ_args)) in
       let swap = ((((i_o, ii_o), i), u_o), destConstruct (first_fun c_o_lifted)) in
-      sigma, swap)
+      sigma, if Option.has_some promote_o then swap else reverse swap)
     (range 1 (ncons + 1))  

--- a/plugin/src/ornaments/promotion.ml
+++ b/plugin/src/ornaments/promotion.ml
@@ -52,8 +52,5 @@ let swap_map_of_promote_or_forget env a b promote_o forget_o =
       let typ_args = unfold_args c_o_typ in
       let sigma, c_o_lifted = reduce_nf env_c_o sigma (mkAppl (f, snoc c_o_app typ_args)) in
       let swap = ((((i_o, ii_o), i), u_o), destConstruct (first_fun c_o_lifted)) in
-      if Option.has_some promote_o then
-        sigma, swap
-      else
-        sigma, reverse swap)
+      sigma, swap)
     (range 1 (ncons + 1))  

--- a/plugin/src/ornaments/promotion.mli
+++ b/plugin/src/ornaments/promotion.mli
@@ -8,7 +8,7 @@ open Constr
 type kind_of_orn =
   | Algebraic of constr * int
   | CurryRecord
-  | SwapConstruct of int * int
+  | SwapConstruct of (int * int) list
 
 (*
  * An ornamental promotion is a function from T1 -> T2,

--- a/plugin/src/ornaments/promotion.mli
+++ b/plugin/src/ornaments/promotion.mli
@@ -1,4 +1,7 @@
 open Constr
+open Environ
+open Evd
+open Stateutils
 
 (* --- Ornamental promotions --- *)
 
@@ -20,3 +23,17 @@ type promotion =
     forget : types;
     kind : kind_of_orn;
   }
+
+(* --- Useful function for finding swaps from promotion function --- *)
+
+(*
+ * This assumes exactly one of promote or forget is present
+ *)
+val swap_map_of_promote_or_forget :
+  env ->
+  types -> (* a *)
+  types -> (* b *)
+  constr option -> (* promote, if present *)
+  constr option -> (* forget, if present *)
+  evar_map ->
+  ((pconstructor * pconstructor) list) state

--- a/plugin/test.sh
+++ b/plugin/test.sh
@@ -17,6 +17,7 @@ morerecords=false
 smartcache=false
 nosmartcache=false
 prodrect=false
+swap=false
 
 start=$SECONDS
 
@@ -83,6 +84,13 @@ else
 fi
 
 cd ..
+
+if coqc coq/Swap.v
+then
+  swap=true
+else
+  :
+fi
 
 echo "Testing smart cache."
 echo "First, without the smart cache:"
@@ -196,7 +204,8 @@ if [ $lifted = true ] && [ $liftedind = true ] && [ $findlift = true ] &&
    [ $liftedcase = true ] && [ $assumptions = true ] && [ $intro = true ] &&
    [ $example = true ] && [ $liftspec = true ] && [ $search = true ] && 
    [ $lift = true ] && [ $listtovect = true ] && [ $listtovectcustom = true ] && [ $records = true ] &&
-   [ $morerecords = true ] && [ $nosmartcache = true ] && [ $smartcache = true ] && [ $prodrect = true ]
+   [ $morerecords = true ] && [ $nosmartcache = true ] && [ $smartcache = true ] && [ $prodrect = true ] &&
+   [ $swap = true ]
 then
   echo "SUCCESS: All tests passed."
 
@@ -237,6 +246,12 @@ else
   if [ $prodrect = false ]
   then
     echo "lifting records to products: folding projections"
+  else
+    :
+  fi
+  if [ $swap = false ]
+  then
+    echo "tests for swapping and renaming constructors"
   else
     :
   fi


### PR DESCRIPTION
Add support for swapping and renaming constructors, including:
- Searching for those equivalences
- Asking for clarification when there are many possible equivalences
- Lifting across those equivalences
- Making it possible to provide just one direction of an for any ornament
